### PR TITLE
[Bug]add openai to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pathlib2
 PyPDF2>=2.0.0
 reportlab>=3.5.0
 streamlit
+openai


### PR DESCRIPTION
## Description
openai module is required, add openai to requirements.txt

## Related Issues
openai module is required, Otherwise, the build will fail

## Changes Made
add openai to requirements.txt
