### PR TITLE
refactor(cli): convert main() to Click command group

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiofiles>=0.8.0
 aiohttp>=3.8.0
 anthropic
 asyncio-mqtt
+click>=8.0.0
 docling
 mcp-agent
 mcp-server-git


### PR DESCRIPTION
## Summary

Converts the free-standing `main()` coroutine into a proper Click command group to enable adding sub-commands (like `deepcode config` or `deepcode clean`) without touching the main logic.

## Changes

- **Convert `main()` to Click group**: Using `@click.group(invoke_without_command=True)` decorator
- **Add `run` sub-command**: Explicit command for starting the interactive session
- **Backwards compatible**: Invoking without a sub-command still starts the interactive session
- **Security improvement**: Replace shell-based `__pycache__` cleanup (`find`/`powershell`) with secure `shutil.rmtree` approach
- **Add dependency**: `click>=8.0.0` added to `requirements.txt`

## Usage

```bash
# Start interactive session (backwards compatible)
python -m cli.cli_app

# Or explicitly with sub-command
python -m cli.cli_app run

# View available commands
python -m cli.cli_app --help
```

## Adding new sub-commands

New sub-commands can be added easily:

```python
@main.command("config")
def config_cmd() -> None:
    """Manage DeepCode configuration."""
    # config logic here

@main.command("clean")
def clean_cmd() -> None:
    """Clean up generated files and caches."""
    # clean logic here
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author