### PR TITLE
Add missing __init__.py files for prompts and config packages

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,1 @@
+# config package

--- a/prompts/__init__.py
+++ b/prompts/__init__.py
@@ -1,0 +1,1 @@
+# prompts package


### PR DESCRIPTION
## Summary
Fixes #87 - `ModuleNotFoundError: No module named 'prompts'`

**Root cause:** The `prompts` and `config` directories were missing `__init__.py` files, so Python couldn't recognize them as packages and `setuptools.find_packages()` couldn't discover them during installation.

**Changes:**
- Add `prompts/__init__.py`
- Add `config/__init__.py`

## Test plan
```python
# Before fix: ModuleNotFoundError
# After fix:
>>> from prompts.code_prompts import PAPER_INPUT_ANALYZER_PROMPT
>>> from config.mcp_tool_definitions import get_mcp_tools
# Both imports succeed
```