### PR TITLE
feat: Add Forge as LLM provider

### DIFF
--- a/nanobot/README.md
+++ b/nanobot/README.md
@@ -516,6 +516,7 @@ Config file: `~/.nanobot/config.json`
 | Provider | Purpose | Get API Key |
 |----------|---------|-------------|
 | `openrouter` | LLM (recommended, access to all models) | [openrouter.ai](https://openrouter.ai) |
+| `forge` | LLM (API gateway, OpenAI-compatible) | [forge.tensorblock.co](https://forge.tensorblock.co) |
 | `anthropic` | LLM (Claude direct) | [console.anthropic.com](https://console.anthropic.com) |
 | `openai` | LLM (GPT direct) | [platform.openai.com](https://platform.openai.com) |
 | `deepseek` | LLM (DeepSeek direct) | [platform.deepseek.com](https://platform.deepseek.com) |

--- a/nanobot/nanobot/config/schema.py
+++ b/nanobot/nanobot/config/schema.py
@@ -165,6 +165,7 @@ class ProvidersConfig(BaseModel):
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
+    forge: ProviderConfig = Field(default_factory=ProviderConfig)
     deepseek: ProviderConfig = Field(default_factory=ProviderConfig)
     groq: ProviderConfig = Field(default_factory=ProviderConfig)
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)

--- a/nanobot/nanobot/providers/litellm_provider.py
+++ b/nanobot/nanobot/providers/litellm_provider.py
@@ -68,7 +68,10 @@ class LiteLLMProvider(LLMProvider):
         for env_name, env_val in spec.env_extras:
             resolved = env_val.replace("{api_key}", api_key)
             resolved = resolved.replace("{api_base}", effective_base)
-            os.environ.setdefault(env_name, resolved)
+            if self._gateway:
+                os.environ[env_name] = resolved
+            else:
+                os.environ.setdefault(env_name, resolved)
 
     def _resolve_model(self, model: str) -> str:
         """Resolve model name by applying provider/gateway prefixes."""

--- a/nanobot/nanobot/providers/registry.py
+++ b/nanobot/nanobot/providers/registry.py
@@ -80,6 +80,26 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         strip_model_prefix=False,
         model_overrides=(),
     ),
+    # Forge: OpenAI-compatible gateway.
+    ProviderSpec(
+        name="forge",
+        keywords=("forge",),
+        env_key="FORGE_API_KEY",
+        display_name="Forge",
+        litellm_prefix="openai",  # route via OpenAI-compatible API
+        skip_prefixes=(),
+        env_extras=(
+            ("OPENAI_API_KEY", "{api_key}"),
+            ("FORGE_API_BASE", "{api_base}"),
+        ),
+        is_gateway=True,
+        is_local=False,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="forge.tensorblock.co",
+        default_api_base="https://api.forge.tensorblock.co/v1",
+        strip_model_prefix=True,
+        model_overrides=(),
+    ),
     # AiHubMix: global gateway, OpenAI-compatible interface.
     # strip_model_prefix=True: it doesn't understand "anthropic/claude-3",
     # so we strip to bare "claude-3" then re-prefix as "openai/claude-3".


### PR DESCRIPTION
## Description

Adds Forge as an OpenAI-compatible gateway provider in nanobot's provider registry, following the same pattern as AiHubMix.

## Changes Made

- `nanobot/nanobot/providers/registry.py`: Added `ProviderSpec` for Forge with `is_gateway=True`, `litellm_prefix="openai"`, `strip_model_prefix=True`
- `nanobot/nanobot/config/schema.py`: Added `forge` field to `ProvidersConfig`
- `nanobot/nanobot/providers/litellm_provider.py`: Extended `env_extras` handling to use `os.environ[...]` (override) for gateways instead of `setdefault`, matching the primary `env_key` pattern at line 60
- `nanobot/README.md`: Added Forge to provider table

## Usage

```yaml
# In nanobot config:
providers:
  forge:
    api_key: "your-forge-api-key"
    api_base: "https://api.forge.tensorblock.co/v1"  # optional, this is the default
```

## Checklist

- [x] Changes tested locally
- [x] Documentation updated
- [x] Ran pre-commit hooks

I work at TensorBlock and will help maintain this integration.

---

## About Forge

[Forge](https://github.com/TensorBlock/forge) is an open-source middleware service for unified AI model provider management. It routes requests across 40+ AI providers with access to thousands of models through a single OpenAI-compatible API.

- Repo: https://github.com/TensorBlock/forge
- Docs: https://www.tensorblock.co/api-docs/overview