### PR TITLE
fix(backend): prevent path traversal in SPA catch-all route (#126)

### DIFF
--- a/new_ui/backend/main.py
+++ b/new_ui/backend/main.py
@@ -167,12 +167,17 @@ if IS_DOCKER and FRONTEND_DIST.exists():
     @app.get("/{full_path:path}")
     async def serve_spa(request: Request, full_path: str):
         """Serve frontend SPA - fallback to index.html for client-side routing"""
-        # Check if a static file exists at the requested path
-        file_path = FRONTEND_DIST / full_path
-        if full_path and file_path.exists() and file_path.is_file():
-            return FileResponse(file_path)
+        frontend_root = FRONTEND_DIST.resolve()
+        if full_path:
+            # Resolve and confirm the path stays inside the build dir before
+            # serving: pathlib "/" join keeps ".." segments and percent-encoded
+            # separators (%2F, %2E%2E) survive Starlette routing, so an
+            # unchecked join allows reading arbitrary files outside the dist dir.
+            requested = (frontend_root / full_path).resolve()
+            if requested.is_relative_to(frontend_root) and requested.is_file():
+                return FileResponse(requested)
         # Otherwise return index.html (SPA routing)
-        return FileResponse(FRONTEND_DIST / "index.html")
+        return FileResponse(frontend_root / "index.html")
 else:
     # Development mode endpoints
     @app.get("/")


### PR DESCRIPTION
## Summary
Fixes #126 — arbitrary file read via path traversal in the Docker/production SPA catch-all route `GET /{full_path:path}` in `new_ui/backend/main.py`.

The route joined the caller-supplied `full_path` directly onto `FRONTEND_DIST` and called `exists()`/`is_file()` on the un-resolved path. `pathlib`'s `/` join does not strip `..` segments, and percent-encoded separators (`%2F`) and dots (`%2E%2E`) survive Starlette's URL normalisation because the path parameter is decoded *after* routing. An unauthenticated client could read any file the process could access (SSH keys, secrets, `/etc/passwd`) outside the build directory.

## Fix
Resolve the joined path and verify it stays within the resolved `FRONTEND_DIST` using `is_relative_to` before serving; otherwise fall back to `index.html`. `is_relative_to` requires Python 3.9+, matching `setup.py`'s `python_requires>=3.9`.

## Verification
Reproduced the original leak and confirmed the fix blocks it via a FastAPI `TestClient` against both old and new handlers:

| Request | Before | After |
|---------|--------|-------|
| `GET /app.js` (legit asset) | 200, served | 200, served |
| `GET /..%2F..%2F..%2Fsecret_key` | 200, **key leaked** | 200, index.html (no leak) |