### PR TITLE
fix(code_indexer): honor ensure_ascii config instead of inverting it

### DIFF
--- a/tools/code_indexer.py
+++ b/tools/code_indexer.py
@@ -1128,7 +1128,7 @@ class CodeIndexer:
                 # Get output configuration
                 output_config = self.indexer_config.get("output", {})
                 json_indent = output_config.get("json_indent", 2)
-                ensure_ascii = not output_config.get("ensure_ascii", False)
+                ensure_ascii = output_config.get("ensure_ascii", False)
 
                 # Save to JSON file
                 with open(output_file, "w", encoding="utf-8") as f:
@@ -1322,7 +1322,7 @@ class CodeIndexer:
         # Get output configuration
         output_config = self.indexer_config.get("output", {})
         json_indent = output_config.get("json_indent", 2)
-        ensure_ascii = not output_config.get("ensure_ascii", False)
+        ensure_ascii = output_config.get("ensure_ascii", False)
 
         with open(stats_path, "w", encoding="utf-8") as f:
             json.dump(
@@ -1338,7 +1338,7 @@ class CodeIndexer:
         # Get output configuration from config file
         output_config = self.indexer_config.get("output", {})
         json_indent = output_config.get("json_indent", 2)
-        ensure_ascii = not output_config.get("ensure_ascii", False)
+        ensure_ascii = output_config.get("ensure_ascii", False)
 
         summary_data = {
             "indexing_completion_time": datetime.now().isoformat(),


### PR DESCRIPTION
## Problem

Three JSON-writing paths in `tools/code_indexer.py` invert the `ensure_ascii` config flag:

```python
json_indent = output_config.get("json_indent", 2)
ensure_ascii = not output_config.get("ensure_ascii", False)   # <-- stray `not`
...
json.dump(index_data, f, indent=json_indent, ensure_ascii=ensure_ascii)
```

(at lines 1131 / 1325 / 1341 — `build_all_indexes`, `generate_statistics_report`, `generate_summary_report`).

This is clearly meant to be a pass-through:
- the sibling option one line above, `json_indent`, is read verbatim with no `not`;
- the config field is literally named `ensure_ascii` — the same keyword it feeds to `json.dump`;
- `json.dump` is used with `ensure_ascii=False` directly elsewhere in the file (line 445).

The shipped default is `ensure_ascii: false` (`tools/indexer_config.yaml:100`), i.e. keep literal UTF-8. But `not False` → `True`, so the code escapes every non-ASCII character (Chinese text, accented identifiers in LLM-generated file summaries/concepts) as `\uXXXX` in the index/statistics/summary JSON — the opposite of the configured behavior.

## Reproduction

Config `{"ensure_ascii": false}`, data `{"summary": "推荐 café"}`:

| | output |
|---|---|
| before (`not` inverts) | `{"summary": "推荐 café"}` ❌ |
| after (pass-through) | `{"summary": "推荐 café"}` ✅ |

These functions are live: `workflows/codebase_index_workflow.py` invokes `build_all_indexes()`, `generate_summary_report()`, and `generate_statistics_report()`.

## Fix

Drop the `not` at all three sites:

```python
ensure_ascii = output_config.get("ensure_ascii", False)
```

No test suite currently covers `code_indexer.py`. `python -m py_compile tools/code_indexer.py` passes.
