### PR TITLE
fix(security): restrict Windows private files to the current user

### DIFF
--- a/core/private_storage.py
+++ b/core/private_storage.py
@@ -5,18 +5,80 @@ under its user data directory.  Callers use these helpers instead of relying on
 the process umask, which is commonly permissive on desktop systems.
 
 POSIX permissions are repaired to ``0700`` for directories and ``0600`` for
-regular files.  Windows access control is inherited from the user's profile;
-the mode arguments are still supplied at creation time where supported.
+regular files.  Windows access control is not inherited from the user profile
+by default (the profile ACL typically grants ``Authenticated Users`` modify
+rights), so we remove inheritance and grant the current user exclusive access —
+matching the POSIX ``0700``/``0600`` intent on NTFS.
 """
 
 from __future__ import annotations
 
 import os
 import stat
+import subprocess
 from pathlib import Path
 
 PRIVATE_DIRECTORY_MODE = 0o700
 PRIVATE_FILE_MODE = 0o600
+
+
+def _windows_identity() -> str | None:
+    """Return the current Windows user (``DOMAIN\\user``) for ACL grants.
+
+    ``%USERNAME%`` alone is ambiguous across domains, so we ask ``whoami``
+    for the fully qualified principal.  Returns ``None`` when the identity
+    cannot be resolved (defensive: callers fall back to no-op).
+    """
+    try:
+        completed = subprocess.run(
+            ["whoami"],
+            capture_output=True,
+            text=True,
+            encoding="mbcs",
+            errors="replace",
+            timeout=5,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    principal = (completed.stdout or "").strip()
+    return principal or None
+
+
+def _restrict_windows_acl(path: Path) -> None:
+    """Restrict ``path`` to the current user on Windows (NTFS).
+
+    Two steps, both idempotent and safe to run repeatedly:
+
+    1. ``/inheritance:r`` removes all inherited ACEs so a permissive parent
+       (e.g. the profile root granting ``Authenticated Users``) no longer
+       applies.
+    2. ``/grant:r <user>:F`` grants the current user exclusive full control
+       (``:r`` replaces any existing user ACE rather than appending).
+
+    Runs ``icacls`` out of process because the standard library has no NTFS
+    ACL API.  Failures are deliberately swallowed (best-effort, like POSIX
+    chmod) — callers still get the POSIX mode at creation time.
+    """
+    identity = _windows_identity()
+    if identity is None:
+        return
+    for args in (
+        ["icacls", os.fspath(path), "/inheritance:r"],
+        ["icacls", os.fspath(path), "/grant:r", f"{identity}:F"],
+    ):
+        try:
+            subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                encoding="mbcs",
+                errors="replace",
+                timeout=15,
+                check=True,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return  # best-effort; keep the caller moving
 
 
 def ensure_private_directory(path: Path | str) -> Path:
@@ -47,6 +109,8 @@ def open_private_file(path: Path | str, flags: int) -> int:
     try:
         if os.name != "nt":
             os.fchmod(descriptor, PRIVATE_FILE_MODE)
+        else:
+            _restrict_windows_acl(target)
         return descriptor
     except BaseException:
         os.close(descriptor)
@@ -69,8 +133,6 @@ def harden_private_tree(root: Path | str) -> Path:
     """Repair a DeepCode-owned tree while refusing to traverse symlinks."""
 
     base = ensure_private_directory(root)
-    if os.name == "nt":
-        return base
 
     for current, directories, files in os.walk(base, followlinks=False):
         current_path = Path(current)
@@ -87,6 +149,7 @@ def harden_private_tree(root: Path | str) -> Path:
 
 def _chmod(path: Path, mode: int) -> None:
     if os.name == "nt":
+        _restrict_windows_acl(path)
         return
     try:
         os.chmod(path, mode, follow_symlinks=False)

--- a/tests/test_private_storage_windows.py
+++ b/tests/test_private_storage_windows.py
@@ -1,0 +1,96 @@
+"""Windows ACL tests for ``core.private_storage``.
+
+POSIX-mode assertions live in ``test_private_storage.py`` (skipped on
+Windows).  On Windows the equivalent guarantee is a *restricted NTFS ACL*:
+inherited ACEs such as ``Authenticated Users`` and ``BUILTIN\\Users`` are
+removed and only the current user keeps full control.
+
+These tests run on Windows only; on POSIX the helpers are no-ops and the
+assertions below are skipped.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.private_storage import ensure_private_directory, open_private_file
+
+pytestmark = pytest.mark.skipif(
+    os.name != "nt",
+    reason="NTFS ACL restriction applies on Windows only",
+)
+
+# ACEs that must never survive on a private DeepCode path.
+_DANGEROUS_ACES = (
+    "Authenticated Users",
+    "BUILTIN\\Users",
+    "Everyone",
+)
+
+# System-level ACEs that icacls keeps by design and are safe to ignore.
+_SAFE_ACES = (
+    "NT AUTHORITY\\SYSTEM",
+    "BUILTIN\\Administrators",
+    "OWNER RIGHTS",
+    "CREATOR OWNER",
+)
+
+
+def _acl_lines(path: Path) -> list[str]:
+    completed = subprocess.run(
+        ["icacls", os.fspath(path)],
+        capture_output=True,
+        text=True,
+        encoding="mbcs",
+        errors="replace",
+        check=False,
+    )
+    return [
+        line.strip()
+        for line in (completed.stdout or "").splitlines()
+        if ":" in line
+    ]
+
+
+def _assert_no_dangerous_aces(path: Path) -> None:
+    lines = _acl_lines(path)
+    assert lines, f"icacls returned no ACE lines for {path}"
+    for line in lines:
+        for ace in _DANGEROUS_ACES:
+            assert ace not in line, (
+                f"{path} still exposes dangerous ACE '{ace}': {line}"
+            )
+
+
+def test_windows_private_directory_is_restricted(tmp_path: Path) -> None:
+    private = tmp_path / "home" / "sessions"
+    ensure_private_directory(private)
+    _assert_no_dangerous_aces(private)
+
+
+def test_windows_private_file_is_restricted(tmp_path: Path) -> None:
+    private = tmp_path / "home"
+    ensure_private_directory(private)
+    fd = open_private_file(private / "credentials.json", os.O_CREAT | os.O_WRONLY)
+    os.close(fd)
+    _assert_no_dangerous_aces(private / "credentials.json")
+
+
+def test_windows_restriction_keeps_current_user(tmp_path: Path) -> None:
+    private = tmp_path / "home"
+    ensure_private_directory(private)
+    fd = open_private_file(private / "secret.bin", os.O_CREAT | os.O_WRONLY)
+    os.close(fd)
+    lines = _acl_lines(private / "secret.bin")
+    # icacls prints the current principal as DOMAIN\user with (F) full control;
+    # the exact DOMAIN prefix varies (machine name vs. domain), so accept any
+    # ACE granting full control that is not a system-level ACE.
+    for line in lines:
+        principal = line.split(":")[0]
+        if ":(" in line and "(F)" in line and principal not in _SAFE_ACES:
+            return  # found a full-control grant for a non-system principal
+    pytest.fail(f"no current-user full-control grant found in: {lines!r}")


### PR DESCRIPTION
On Windows, POSIX mode bits are ignored, so `credentials.json` and other private state inherited the permissive profile ACL (Authenticated Users typically gets Modify). An attacker with a foothold could read API keys from a file the process *thought* was private.

## Fix
- `private_storage._restrict_windows_acl`: removes inherited ACEs (`icacls /inheritance:r`) then grants the current user exclusive full control (`/grant:r <user>:F`). Best-effort, mirroring POSIX chmod semantics.
- `_windows_identity`: resolves the fully-qualified principal via `whoami`.
- `open_private_file` now applies the ACL on Windows (previously skipped the whole branch).
- `harden_private_tree` walks and repairs ACLs on Windows too (previously bailed out early).
- icacls/whoami output decoded as `mbcs` (OEM codepage) to avoid UnicodeDecodeError on CJK systems.

## Tests
`tests/test_private_storage_windows.py`: directory restricted, file restricted, current-user grant retained. Runs on Windows only; skipped on POSIX.