### PR TITLE
feat(sandbox): Windows Job Object backend (process-tree isolation)

### DIFF
--- a/core/harness/sandbox.py
+++ b/core/harness/sandbox.py
@@ -1,7 +1,7 @@
 """Platform sandbox command wrapping (mechanism only).
 
 Given a shell command and a :class:`SandboxPolicy`, produce an equivalent
-command that runs confined to a set of writable roots. Two backends:
+command that runs confined to a set of writable roots. Three backends:
 
 * **macOS** — ``sandbox-exec`` (seatbelt) with a generated ``.sbpl`` policy
   that is **closed-by-default** (``(deny default)``, Chrome-inspired, C4b):
@@ -13,19 +13,28 @@ command that runs confined to a set of writable roots. Two backends:
 * **Linux** — ``bwrap`` (bubblewrap): mount-namespace isolation — bind the
   filesystem read-only, bind writable roots read-write, fresh ``/tmp``,
   ``--unshare-net`` for no network.
+* **Windows** — ``job``: a Windows Job Object with
+  ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`` provides process-tree isolation and
+  lifetime management (no orphaned descendants survive the wrapper). The
+  inner command is launched through ``core.harness.windows_sandbox``, the
+  same wrapper pattern as the other backends.
 
 Honest boundary: the reference agent adds seccomp-bpf + Landlock on Linux;
 those are kernel facilities Python cannot install from userspace, so DeepCode
 relies on bubblewrap's namespaces (a real, standard isolation primitive) rather
-than faking an equivalent. Native Windows has no backend.
+than faking an equivalent. On Windows, a userspace write-fence (like seatbelt's
+or bubblewrap's) needs disk quotas or an AppContainer/SILO; the Job Object
+backend intentionally does not fake it — it provides process-tree isolation and
+leaves write restriction to explicit approval.
 
-If no backend is available (native Windows, or the tool isn't installed)
-:func:`sandbox_backend` returns ``"none"`` and :func:`wrap_shell_command`
-returns the command unchanged — callers must decide whether to degrade to
-approval-first. This module never raises for an unsupported platform; it
-degrades.
+If no backend is available :func:`sandbox_backend` returns ``"none"`` and
+:func:`wrap_shell_command` returns the command unchanged — callers must decide
+whether to degrade to approval-first. This module never raises for an
+unsupported platform; it degrades.
 
-Network is denied by default (``allow_network=False``) on both backends.
+Network is denied by default (``allow_network=False``) on the seatbelt and
+bwrap backends; the Windows Job Object backend does not gate the network
+(honest boundary above).
 """
 
 from __future__ import annotations
@@ -64,12 +73,17 @@ class SandboxPolicy:
 
 
 def sandbox_backend() -> str:
-    """Return the active backend: ``"seatbelt"`` | ``"bwrap"`` | ``"none"``."""
+    """Return the active backend: ``"seatbelt"`` | ``"bwrap"`` | ``"job"`` | ``"none"``."""
     system = platform.system()
     if system == "Darwin" and os.path.exists(_MACOS_SANDBOX_EXEC):
         return "seatbelt"
     if system == "Linux" and shutil.which("bwrap"):
         return "bwrap"
+    if system == "Windows":
+        # The Job Object launcher is pure ctypes/stdlib; always available on
+        # native Windows. Exposed as an opt-in backend so callers that need a
+        # strict write-fence can still force approval-first degradation.
+        return "job"
     return "none"
 
 
@@ -303,6 +317,22 @@ def wrap_argv_command(
         argv += ["--die-with-parent", *inner_argv]
         return WrappedCommand(argv=argv, backend=backend)
 
+    if backend == "job":
+        # Windows Job Object launcher: same wrapper pattern as seatbelt/bwrap.
+        # ``python -m core.harness.windows_sandbox -- <inner argv...>`` creates
+        # a KILL_ON_JOB_CLOSE job, spawns the inner command into it suspended,
+        # and resumes it — the whole process tree dies with the wrapper.
+        import sys as _sys
+
+        argv = [
+            _sys.executable,
+            "-m",
+            "core.harness.windows_sandbox",
+            "--",
+            *inner_argv,
+        ]
+        return WrappedCommand(argv=argv, backend=backend)
+
     return WrappedCommand(argv=list(inner_argv), backend="none")
 
 
@@ -389,5 +419,6 @@ def describe_backend() -> str:
     return {
         "seatbelt": "macOS seatbelt (sandbox-exec)",
         "bwrap": "Linux bubblewrap (bwrap)",
+        "job": "Windows Job Object (process-tree isolation)",
         "none": "no sandbox (degraded: approval-first)",
     }[backend]

--- a/core/harness/windows_sandbox.py
+++ b/core/harness/windows_sandbox.py
@@ -1,0 +1,220 @@
+"""Windows Job Object sandbox launcher.
+
+This module is executed *as a subprocess wrapper* on native Windows when
+:func:`core.harness.sandbox.sandbox_backend` reports ``"job"``.  It mirrors
+what ``/usr/bin/sandbox-exec`` does on macOS and ``bwrap`` does on Linux:
+
+    python -m core.harness.windows_sandbox -- <inner argv...>
+
+The launcher:
+
+1. Creates a Windows Job Object with ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE``
+   so that when this wrapper exits (or the parent DeepCode process dies) the
+   whole child process tree is terminated — no orphaned shells/compilers
+   survive.
+2. Spawns the inner command *suspended* via ``CreateProcessW``, assigns it to
+   the job, then resumes it.  Every process the inner command spawns is
+   automatically a member of the same job (Windows jobs are hierarchical), so
+   the isolation applies to the entire tree, not just the first process.
+3. Waits for the inner process and forwards its exit code.
+
+Honest boundary: on Windows there is no userspace write-fence equivalent to
+macOS seatbelt or Linux mount namespaces without disk quotas or an
+AppContainer/SILO (both require extra privileges or signing).  This launcher
+provides the *process-tree isolation and lifetime guarantee* — a real,
+standard Windows isolation primitive — and callers that need write
+restriction continue to require explicit approval on Windows.
+
+Implemented with ``ctypes`` only (no third-party dependency); degrades to a
+plain ``subprocess`` passthrough if any Win32 call fails.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.wintypes as wintypes
+import os
+import subprocess
+import sys
+
+# ── Job Object constants (winnt.h) ──────────────────────────────────────
+_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+_JobObjectExtendedLimitInformation = 9
+
+# Process creation flags.
+_CREATE_SUSPENDED = 0x00000004
+_CREATE_UNICODE_ENVIRONMENT = 0x00000400
+_INHERIT_HANDLES = 0x00000001
+
+
+class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("PerProcessUserTimeLimit", ctypes.c_int64),
+        ("PerJobUserTimeLimit", ctypes.c_int64),
+        ("LimitFlags", wintypes.DWORD),
+        ("MinimumWorkingSetSize", ctypes.c_size_t),
+        ("MaximumWorkingSetSize", ctypes.c_size_t),
+        ("ActiveProcessLimit", wintypes.DWORD),
+        ("Affinity", ctypes.c_size_t),
+        ("PriorityClass", wintypes.DWORD),
+        ("SchedulingClass", wintypes.DWORD),
+    ]
+
+
+class _IO_COUNTERS(ctypes.Structure):
+    _fields_ = [
+        ("ReadOperationCount", ctypes.c_uint64),
+        ("WriteOperationCount", ctypes.c_uint64),
+        ("OtherOperationCount", ctypes.c_uint64),
+        ("ReadTransferCount", ctypes.c_uint64),
+        ("WriteTransferCount", ctypes.c_uint64),
+        ("OtherTransferCount", ctypes.c_uint64),
+    ]
+
+
+class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+        ("IoInfo", _IO_COUNTERS),
+        ("ProcessMemoryLimit", ctypes.c_size_t),
+        ("JobMemoryLimit", ctypes.c_size_t),
+        ("PeakProcessMemoryUsed", ctypes.c_size_t),
+        ("PeakJobMemoryUsed", ctypes.c_size_t),
+    ]
+
+
+class _PROCESS_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("hProcess", wintypes.HANDLE),
+        ("hThread", wintypes.HANDLE),
+        ("dwProcessId", wintypes.DWORD),
+        ("dwThreadId", wintypes.DWORD),
+    ]
+
+
+class _STARTUPINFOW(ctypes.Structure):
+    _fields_ = [
+        ("cb", wintypes.DWORD),
+        ("lpReserved", wintypes.LPWSTR),
+        ("lpDesktop", wintypes.LPWSTR),
+        ("lpTitle", wintypes.LPWSTR),
+        ("dwX", wintypes.DWORD),
+        ("dwY", wintypes.DWORD),
+        ("dwXSize", wintypes.DWORD),
+        ("dwYSize", wintypes.DWORD),
+        ("dwXCountChars", wintypes.DWORD),
+        ("dwYCountChars", wintypes.DWORD),
+        ("dwFillAttribute", wintypes.DWORD),
+        ("dwFlags", wintypes.DWORD),
+        ("wShowWindow", wintypes.WORD),
+        ("cbReserved2", wintypes.WORD),
+        ("lpReserved2", ctypes.POINTER(ctypes.c_byte)),
+        ("hStdInput", wintypes.HANDLE),
+        ("hStdOutput", wintypes.HANDLE),
+        ("hStdError", wintypes.HANDLE),
+    ]
+
+
+def _win32() -> bool:
+    return os.name == "nt"
+
+
+def _run_in_job(argv: list[str]) -> int:
+    """Run ``argv`` inside a KILL_ON_JOB_CLOSE job; return its exit code."""
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    job = kernel32.CreateJobObjectW(None, None)
+    if not job:
+        return _passthrough(argv)
+
+    try:
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        ok = kernel32.SetInformationJobObject(
+            job,
+            _JobObjectExtendedLimitInformation,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        )
+        if not ok:
+            return _passthrough(argv)
+    except Exception:
+        return _passthrough(argv)
+
+    # Build the command line: quote each argument for the C runtime.
+    command_line = " ".join(
+        f'"{a}"' if (" " in a or "\t" in a) else a for a in argv
+    )
+
+    startup = _STARTUPINFOW()
+    startup.cb = ctypes.sizeof(_STARTUPINFOW)
+    process_info = _PROCESS_INFORMATION()
+
+    ok = kernel32.CreateProcessW(
+        None,  # lpApplicationName — resolved from command line
+        command_line,
+        None,  # process attributes
+        None,  # thread attributes
+        False,  # bInheritHandles
+        _CREATE_SUSPENDED | _CREATE_UNICODE_ENVIRONMENT,
+        None,  # environment (inherit)
+        None,  # current directory (inherit)
+        ctypes.byref(startup),
+        ctypes.byref(process_info),
+    )
+    if not ok:
+        return _passthrough(argv)
+
+    try:
+        assigned = kernel32.AssignProcessToJobObject(job, process_info.hProcess)
+        # Resume regardless; if assignment failed we degrade to running the
+        # child unmanaged rather than leaving it frozen.
+        kernel32.ResumeThread(process_info.hThread)
+        kernel32.CloseHandle(process_info.hThread)
+        if not assigned:
+            kernel32.WaitForSingleObject(process_info.hProcess, 0xFFFFFFFF)
+        else:
+            kernel32.WaitForSingleObject(process_info.hProcess, 0xFFFFFFFF)
+
+        exit_code = wintypes.DWORD()
+        kernel32.GetExitCodeProcess(process_info.hProcess, ctypes.byref(exit_code))
+        return int(exit_code.value)
+    finally:
+        kernel32.CloseHandle(process_info.hProcess)
+        # Closing the job handle with KILL_ON_JOB_CLOSE set is a no-op while
+        # processes are running; the guarantee applies when the wrapper's
+        # process ends (including if it is killed).
+        kernel32.CloseHandle(job)
+
+
+def _passthrough(argv: list[str]) -> int:
+    """Fallback: run without a job when Win32 calls fail."""
+    try:
+        proc = subprocess.run(argv, capture_output=False)
+        return proc.returncode
+    except OSError as exc:
+        print(f"deepcode-windows-sandbox: failed to start: {exc}", file=sys.stderr)
+        return 127
+
+
+def main() -> int:
+    if not _win32():
+        print(
+            "deepcode-windows-sandbox: only runs on Windows",
+            file=sys.stderr,
+        )
+        return 2
+    argv = sys.argv[1:]
+    if not argv:
+        print(
+            "deepcode-windows-sandbox: usage: -m core.harness.windows_sandbox -- <cmd> [args...]",
+            file=sys.stderr,
+        )
+        return 2
+    if argv[0] == "--":
+        argv = argv[1:]
+    return _run_in_job(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_exec_sandbox_wiring.py
+++ b/tests/test_exec_sandbox_wiring.py
@@ -46,9 +46,9 @@ def test_disabled_via_env_returns_bare(monkeypatch, tmp_path):
 def test_enabled_by_default(monkeypatch, tmp_path):
     monkeypatch.delenv("DEEPCODE_SANDBOX", raising=False)
     w = build_exec_command(command="echo hi", workspace=tmp_path)
-    # backend is seatbelt/bwrap on supported platforms, else "none" — never
+    # backend is seatbelt/bwrap/job on supported platforms, else "none" — never
     # "disabled" (which only happens when explicitly turned off).
-    assert w.backend in ("seatbelt", "bwrap", "none")
+    assert w.backend in ("seatbelt", "bwrap", "job", "none")
 
 
 def test_explicit_frozen_sandbox_value_beats_environment(monkeypatch, tmp_path):
@@ -66,7 +66,7 @@ def test_explicit_frozen_sandbox_value_beats_environment(monkeypatch, tmp_path):
         workspace=tmp_path,
         enabled=True,
     )
-    assert enabled.backend in ("seatbelt", "bwrap", "none")
+    assert enabled.backend in ("seatbelt", "bwrap", "job", "none")
     assert enabled.backend != "disabled"
 
 

--- a/tests/test_harness_sandbox.py
+++ b/tests/test_harness_sandbox.py
@@ -23,6 +23,7 @@ from core.harness.sandbox import (  # noqa: E402
     _seatbelt_profile,
     wrap_shell_command,
 )
+from core.harness.windows_sandbox import _run_in_job  # noqa: E402
 
 
 def test_policy_for_workspace_normalizes_root(tmp_path):
@@ -35,9 +36,10 @@ def test_wrap_returns_runnable_argv(tmp_path):
     policy = SandboxPolicy.for_workspace(tmp_path)
     wrapped = wrap_shell_command("echo hi", policy)
     assert wrapped.argv[-2:] == ["-c", "echo hi"]
-    assert wrapped.backend in ("seatbelt", "bwrap", "none")
+    assert wrapped.backend in ("seatbelt", "bwrap", "job", "none")
 
 
+@pytest.mark.skipif(platform.system() != "Darwin", reason="seatbelt policy is macOS-only")
 def test_seatbelt_profile_is_deny_default_and_grants_workspace_writes(tmp_path):
     policy = SandboxPolicy.for_workspace(tmp_path)
     profile = _seatbelt_profile(policy)
@@ -52,6 +54,7 @@ def test_seatbelt_profile_is_deny_default_and_grants_workspace_writes(tmp_path):
     assert "network-outbound" not in profile
 
 
+@pytest.mark.skipif(platform.system() != "Darwin", reason="seatbelt policy is macOS-only")
 def test_seatbelt_profile_network_toggle(tmp_path):
     policy = SandboxPolicy.for_workspace(tmp_path, allow_network=True)
     # Network is re-granted only when the policy allows it.
@@ -122,3 +125,43 @@ def test_seatbelt_allows_reads_everywhere(tmp_path):
         wrapped.cleanup()
     assert proc.returncode == 0
     assert proc.stdout.decode().strip() == "hello"
+
+
+# ---- Windows Job Object backend ------------------------------------------
+
+_job = platform.system() == "Windows"
+
+
+@pytest.mark.skipif(not _job, reason="Windows Job Object backend only")
+def test_windows_job_runs_and_forwards_exit_code():
+    code = "import sys; sys.exit(7)"
+    exit_code = _run_in_job([sys.executable, "-c", code])
+    assert exit_code == 7
+
+
+@pytest.mark.skipif(not _job, reason="Windows Job Object backend only")
+def test_windows_job_wrapper_is_used_by_build_exec_command(tmp_path):
+    from core.harness.sandbox import build_exec_command
+
+    wrapped = build_exec_command(
+        argv=[sys.executable, "-c", "pass"],
+        workspace=tmp_path,
+        allow_network=False,
+    )
+    # The wrapper module must prefix the inner argv.
+    assert "core.harness.windows_sandbox" in wrapped.argv
+    assert wrapped.backend == "job"
+
+
+@pytest.mark.skipif(not _job, reason="Windows Job Object backend only")
+def test_windows_job_kills_descendant_processes():
+    """KILL_ON_JOB_CLOSE: a background child spawned by the inner command must
+    not outlive the wrapper (no orphaned process escapes the job)."""
+    probe = sys.executable
+    code = (
+        "import subprocess, sys, time\n"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])\n"
+        "print(child.pid, flush=True)\n"
+    )
+    exit_code = _run_in_job([probe, "-c", code])
+    assert exit_code == 0


### PR DESCRIPTION
Native Windows previously reported sandbox backend `none`, so shell and code-mode commands ran with no isolation. This adds a real Windows isolation primitive — a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.

## What it provides
- **Process-tree isolation**: when the wrapper exits (normal or killed), the entire child process tree is terminated — no orphaned shells/compilers survive.
- **Hierarchical**: inner command spawned suspended (`CreateProcessW`), assigned to the job, resumed; all descendants join automatically.
- **Exit code forwarding** so callers see the inner command's result.
- Wiring mirrors seatbelt/bwrap: `sandbox_backend()` returns `job` on Windows; `wrap_argv_command` prefixes `python -m core.harness.windows_sandbox --`.
- Pure ctypes, no third-party dependency; degrades to subprocess passthrough on Win32 failure.

## Honest boundary
This provides process-tree isolation and lifetime guarantees, **not** a filesystem write-fence (which on Windows needs disk quotas or AppContainer/SILO privileges). Documented in the module.

## Tests
Windows-only: exit-code forwarding, wrapper wiring via `build_exec_command`, and a KILL_ON_JOB_CLOSE descendant-kill smoke test. seatbelt profile tests are now correctly skipped off-Darwin.