### PR TITLE
chore: land PRs #139/#148/#149 with original authorship

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -38,7 +38,7 @@ jobs:
           python -m pytest -q
 
   windows-lifecycle:
-    name: Windows lifecycle locks
+    name: Windows lifecycle locks and platform isolation
     runs-on: windows-2022
 
     steps:
@@ -63,6 +63,16 @@ jobs:
           tests/application/test_automation_scheduler_leadership.py
           tests/application/test_session_deletion_service.py
           tests/application/test_execution_coordinator.py
+
+      # These suites carry Windows-gated cases (NTFS ACLs, the Job Object
+      # backend) that the ubuntu job can only skip. This is the sole place
+      # they actually execute.
+      - name: Verify Windows ACLs and Job Object sandbox
+        run: >-
+          python -m pytest -q
+          tests/test_private_storage_windows.py
+          tests/test_harness_sandbox.py
+          tests/test_exec_sandbox_wiring.py
 
   package:
     runs-on: ubuntu-latest

--- a/core/harness/sandbox.py
+++ b/core/harness/sandbox.py
@@ -413,6 +413,18 @@ def build_exec_command(
     return wrap_argv_command(list(argv or []), policy)
 
 
+#: Backends that confine writes to the policy's writable roots. The Job Object
+#: backend deliberately does not (see the module docstring): it isolates the
+#: process tree but leaves the filesystem open, so callers must not advertise a
+#: write-fence on Windows.
+_WRITE_FENCING_BACKENDS = frozenset({"seatbelt", "bwrap"})
+
+
+def fences_writes() -> bool:
+    """Whether the active backend actually confines writes to the workspace."""
+    return sandbox_backend() in _WRITE_FENCING_BACKENDS
+
+
 def describe_backend() -> str:
     """Human-readable one-liner for logs/prompts."""
     backend = sandbox_backend()

--- a/core/harness/sandbox.py
+++ b/core/harness/sandbox.py
@@ -1,7 +1,7 @@
 """Platform sandbox command wrapping (mechanism only).
 
 Given a shell command and a :class:`SandboxPolicy`, produce an equivalent
-command that runs confined to a set of writable roots. Two backends:
+command that runs confined to a set of writable roots. Three backends:
 
 * **macOS** — ``sandbox-exec`` (seatbelt) with a generated ``.sbpl`` policy
   that is **closed-by-default** (``(deny default)``, Chrome-inspired, C4b):
@@ -13,19 +13,28 @@ command that runs confined to a set of writable roots. Two backends:
 * **Linux** — ``bwrap`` (bubblewrap): mount-namespace isolation — bind the
   filesystem read-only, bind writable roots read-write, fresh ``/tmp``,
   ``--unshare-net`` for no network.
+* **Windows** — ``job``: a Windows Job Object with
+  ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`` provides process-tree isolation and
+  lifetime management (no orphaned descendants survive the wrapper). The
+  inner command is launched through ``core.harness.windows_sandbox``, the
+  same wrapper pattern as the other backends.
 
 Honest boundary: the reference agent adds seccomp-bpf + Landlock on Linux;
 those are kernel facilities Python cannot install from userspace, so DeepCode
 relies on bubblewrap's namespaces (a real, standard isolation primitive) rather
-than faking an equivalent. Native Windows has no backend.
+than faking an equivalent. On Windows, a userspace write-fence (like seatbelt's
+or bubblewrap's) needs disk quotas or an AppContainer/SILO; the Job Object
+backend intentionally does not fake it — it provides process-tree isolation and
+leaves write restriction to explicit approval.
 
-If no backend is available (native Windows, or the tool isn't installed)
-:func:`sandbox_backend` returns ``"none"`` and :func:`wrap_shell_command`
-returns the command unchanged — callers must decide whether to degrade to
-approval-first. This module never raises for an unsupported platform; it
-degrades.
+If no backend is available :func:`sandbox_backend` returns ``"none"`` and
+:func:`wrap_shell_command` returns the command unchanged — callers must decide
+whether to degrade to approval-first. This module never raises for an
+unsupported platform; it degrades.
 
-Network is denied by default (``allow_network=False``) on both backends.
+Network is denied by default (``allow_network=False``) on the seatbelt and
+bwrap backends; the Windows Job Object backend does not gate the network
+(honest boundary above).
 """
 
 from __future__ import annotations
@@ -64,12 +73,17 @@ class SandboxPolicy:
 
 
 def sandbox_backend() -> str:
-    """Return the active backend: ``"seatbelt"`` | ``"bwrap"`` | ``"none"``."""
+    """Return the active backend: ``"seatbelt"`` | ``"bwrap"`` | ``"job"`` | ``"none"``."""
     system = platform.system()
     if system == "Darwin" and os.path.exists(_MACOS_SANDBOX_EXEC):
         return "seatbelt"
     if system == "Linux" and shutil.which("bwrap"):
         return "bwrap"
+    if system == "Windows":
+        # The Job Object launcher is pure ctypes/stdlib; always available on
+        # native Windows. Exposed as an opt-in backend so callers that need a
+        # strict write-fence can still force approval-first degradation.
+        return "job"
     return "none"
 
 
@@ -303,6 +317,22 @@ def wrap_argv_command(
         argv += ["--die-with-parent", *inner_argv]
         return WrappedCommand(argv=argv, backend=backend)
 
+    if backend == "job":
+        # Windows Job Object launcher: same wrapper pattern as seatbelt/bwrap.
+        # ``python -m core.harness.windows_sandbox -- <inner argv...>`` creates
+        # a KILL_ON_JOB_CLOSE job, spawns the inner command into it suspended,
+        # and resumes it — the whole process tree dies with the wrapper.
+        import sys as _sys
+
+        argv = [
+            _sys.executable,
+            "-m",
+            "core.harness.windows_sandbox",
+            "--",
+            *inner_argv,
+        ]
+        return WrappedCommand(argv=argv, backend=backend)
+
     return WrappedCommand(argv=list(inner_argv), backend="none")
 
 
@@ -389,5 +419,6 @@ def describe_backend() -> str:
     return {
         "seatbelt": "macOS seatbelt (sandbox-exec)",
         "bwrap": "Linux bubblewrap (bwrap)",
+        "job": "Windows Job Object (process-tree isolation)",
         "none": "no sandbox (degraded: approval-first)",
     }[backend]

--- a/core/harness/windows_sandbox.py
+++ b/core/harness/windows_sandbox.py
@@ -142,9 +142,7 @@ def _run_in_job(argv: list[str]) -> int:
         return _passthrough(argv)
 
     # Build the command line: quote each argument for the C runtime.
-    command_line = " ".join(
-        f'"{a}"' if (" " in a or "\t" in a) else a for a in argv
-    )
+    command_line = " ".join(f'"{a}"' if (" " in a or "\t" in a) else a for a in argv)
 
     startup = _STARTUPINFOW()
     startup.cb = ctypes.sizeof(_STARTUPINFOW)

--- a/core/harness/windows_sandbox.py
+++ b/core/harness/windows_sandbox.py
@@ -1,0 +1,220 @@
+"""Windows Job Object sandbox launcher.
+
+This module is executed *as a subprocess wrapper* on native Windows when
+:func:`core.harness.sandbox.sandbox_backend` reports ``"job"``.  It mirrors
+what ``/usr/bin/sandbox-exec`` does on macOS and ``bwrap`` does on Linux:
+
+    python -m core.harness.windows_sandbox -- <inner argv...>
+
+The launcher:
+
+1. Creates a Windows Job Object with ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE``
+   so that when this wrapper exits (or the parent DeepCode process dies) the
+   whole child process tree is terminated — no orphaned shells/compilers
+   survive.
+2. Spawns the inner command *suspended* via ``CreateProcessW``, assigns it to
+   the job, then resumes it.  Every process the inner command spawns is
+   automatically a member of the same job (Windows jobs are hierarchical), so
+   the isolation applies to the entire tree, not just the first process.
+3. Waits for the inner process and forwards its exit code.
+
+Honest boundary: on Windows there is no userspace write-fence equivalent to
+macOS seatbelt or Linux mount namespaces without disk quotas or an
+AppContainer/SILO (both require extra privileges or signing).  This launcher
+provides the *process-tree isolation and lifetime guarantee* — a real,
+standard Windows isolation primitive — and callers that need write
+restriction continue to require explicit approval on Windows.
+
+Implemented with ``ctypes`` only (no third-party dependency); degrades to a
+plain ``subprocess`` passthrough if any Win32 call fails.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.wintypes as wintypes
+import os
+import subprocess
+import sys
+
+# ── Job Object constants (winnt.h) ──────────────────────────────────────
+_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+_JobObjectExtendedLimitInformation = 9
+
+# Process creation flags.
+_CREATE_SUSPENDED = 0x00000004
+_CREATE_UNICODE_ENVIRONMENT = 0x00000400
+_INHERIT_HANDLES = 0x00000001
+
+
+class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("PerProcessUserTimeLimit", ctypes.c_int64),
+        ("PerJobUserTimeLimit", ctypes.c_int64),
+        ("LimitFlags", wintypes.DWORD),
+        ("MinimumWorkingSetSize", ctypes.c_size_t),
+        ("MaximumWorkingSetSize", ctypes.c_size_t),
+        ("ActiveProcessLimit", wintypes.DWORD),
+        ("Affinity", ctypes.c_size_t),
+        ("PriorityClass", wintypes.DWORD),
+        ("SchedulingClass", wintypes.DWORD),
+    ]
+
+
+class _IO_COUNTERS(ctypes.Structure):
+    _fields_ = [
+        ("ReadOperationCount", ctypes.c_uint64),
+        ("WriteOperationCount", ctypes.c_uint64),
+        ("OtherOperationCount", ctypes.c_uint64),
+        ("ReadTransferCount", ctypes.c_uint64),
+        ("WriteTransferCount", ctypes.c_uint64),
+        ("OtherTransferCount", ctypes.c_uint64),
+    ]
+
+
+class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+        ("IoInfo", _IO_COUNTERS),
+        ("ProcessMemoryLimit", ctypes.c_size_t),
+        ("JobMemoryLimit", ctypes.c_size_t),
+        ("PeakProcessMemoryUsed", ctypes.c_size_t),
+        ("PeakJobMemoryUsed", ctypes.c_size_t),
+    ]
+
+
+class _PROCESS_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("hProcess", wintypes.HANDLE),
+        ("hThread", wintypes.HANDLE),
+        ("dwProcessId", wintypes.DWORD),
+        ("dwThreadId", wintypes.DWORD),
+    ]
+
+
+class _STARTUPINFOW(ctypes.Structure):
+    _fields_ = [
+        ("cb", wintypes.DWORD),
+        ("lpReserved", wintypes.LPWSTR),
+        ("lpDesktop", wintypes.LPWSTR),
+        ("lpTitle", wintypes.LPWSTR),
+        ("dwX", wintypes.DWORD),
+        ("dwY", wintypes.DWORD),
+        ("dwXSize", wintypes.DWORD),
+        ("dwYSize", wintypes.DWORD),
+        ("dwXCountChars", wintypes.DWORD),
+        ("dwYCountChars", wintypes.DWORD),
+        ("dwFillAttribute", wintypes.DWORD),
+        ("dwFlags", wintypes.DWORD),
+        ("wShowWindow", wintypes.WORD),
+        ("cbReserved2", wintypes.WORD),
+        ("lpReserved2", ctypes.POINTER(ctypes.c_byte)),
+        ("hStdInput", wintypes.HANDLE),
+        ("hStdOutput", wintypes.HANDLE),
+        ("hStdError", wintypes.HANDLE),
+    ]
+
+
+def _win32() -> bool:
+    return os.name == "nt"
+
+
+def _run_in_job(argv: list[str]) -> int:
+    """Run ``argv`` inside a KILL_ON_JOB_CLOSE job; return its exit code."""
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    job = kernel32.CreateJobObjectW(None, None)
+    if not job:
+        return _passthrough(argv)
+
+    try:
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        ok = kernel32.SetInformationJobObject(
+            job,
+            _JobObjectExtendedLimitInformation,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        )
+        if not ok:
+            return _passthrough(argv)
+    except Exception:
+        return _passthrough(argv)
+
+    # Build the command line: quote each argument for the C runtime.
+    command_line = " ".join(
+        f'"{a}"' if (" " in a or "\t" in a) else a for a in argv
+    )
+
+    startup = _STARTUPINFOW()
+    startup.cb = ctypes.sizeof(_STARTUPINFOW)
+    process_info = _PROCESS_INFORMATION()
+
+    ok = kernel32.CreateProcessW(
+        None,  # lpApplicationName — resolved from command line
+        command_line,
+        None,  # process attributes
+        None,  # thread attributes
+        False,  # bInheritHandles
+        _CREATE_SUSPENDED | _CREATE_UNICODE_ENVIRONMENT,
+        None,  # environment (inherit)
+        None,  # current directory (inherit)
+        ctypes.byref(startup),
+        ctypes.byref(process_info),
+    )
+    if not ok:
+        return _passthrough(argv)
+
+    try:
+        assigned = kernel32.AssignProcessToJobObject(job, process_info.hProcess)
+        # Resume regardless; if assignment failed we degrade to running the
+        # child unmanaged rather than leaving it frozen.
+        kernel32.ResumeThread(process_info.hThread)
+        kernel32.CloseHandle(process_info.hThread)
+        if not assigned:
+            kernel32.WaitForSingleObject(process_info.hProcess, 0xFFFFFFFF)
+        else:
+            kernel32.WaitForSingleObject(process_info.hProcess, 0xFFFFFFFF)
+
+        exit_code = wintypes.DWORD()
+        kernel32.GetExitCodeProcess(process_info.hProcess, ctypes.byref(exit_code))
+        return int(exit_code.value)
+    finally:
+        kernel32.CloseHandle(process_info.hProcess)
+        # Closing the job handle with KILL_ON_JOB_CLOSE set is a no-op while
+        # processes are running; the guarantee applies when the wrapper's
+        # process ends (including if it is killed).
+        kernel32.CloseHandle(job)
+
+
+def _passthrough(argv: list[str]) -> int:
+    """Fallback: run without a job when Win32 calls fail."""
+    try:
+        proc = subprocess.run(argv, capture_output=False)
+        return proc.returncode
+    except OSError as exc:
+        print(f"deepcode-windows-sandbox: failed to start: {exc}", file=sys.stderr)
+        return 127
+
+
+def main() -> int:
+    if not _win32():
+        print(
+            "deepcode-windows-sandbox: only runs on Windows",
+            file=sys.stderr,
+        )
+        return 2
+    argv = sys.argv[1:]
+    if not argv:
+        print(
+            "deepcode-windows-sandbox: usage: -m core.harness.windows_sandbox -- <cmd> [args...]",
+            file=sys.stderr,
+        )
+        return 2
+    if argv[0] == "--":
+        argv = argv[1:]
+    return _run_in_job(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/private_storage.py
+++ b/core/private_storage.py
@@ -5,14 +5,17 @@ under its user data directory.  Callers use these helpers instead of relying on
 the process umask, which is commonly permissive on desktop systems.
 
 POSIX permissions are repaired to ``0700`` for directories and ``0600`` for
-regular files.  Windows access control is inherited from the user's profile;
-the mode arguments are still supplied at creation time where supported.
+regular files.  Windows access control is not inherited from the user profile
+by default (the profile ACL typically grants ``Authenticated Users`` modify
+rights), so we remove inheritance and grant the current user exclusive access —
+matching the POSIX ``0700``/``0600`` intent on NTFS.
 """
 
 from __future__ import annotations
 
 import os
 import stat
+import subprocess
 from pathlib import Path
 
 PRIVATE_DIRECTORY_MODE = 0o700
@@ -21,6 +24,65 @@ PRIVATE_FILE_MODE = 0o600
 
 class UnsafePrivateFileError(OSError):
     """A private-state path is not a regular file owned by this path entry."""
+
+
+def _windows_identity() -> str | None:
+    """Return the current Windows user (``DOMAIN\\user``) for ACL grants.
+
+    ``%USERNAME%`` alone is ambiguous across domains, so we ask ``whoami``
+    for the fully qualified principal.  Returns ``None`` when the identity
+    cannot be resolved (defensive: callers fall back to no-op).
+    """
+    try:
+        completed = subprocess.run(
+            ["whoami"],
+            capture_output=True,
+            text=True,
+            encoding="mbcs",
+            errors="replace",
+            timeout=5,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    principal = (completed.stdout or "").strip()
+    return principal or None
+
+
+def _restrict_windows_acl(path: Path) -> None:
+    """Restrict ``path`` to the current user on Windows (NTFS).
+
+    Two steps, both idempotent and safe to run repeatedly:
+
+    1. ``/inheritance:r`` removes all inherited ACEs so a permissive parent
+       (e.g. the profile root granting ``Authenticated Users``) no longer
+       applies.
+    2. ``/grant:r <user>:F`` grants the current user exclusive full control
+       (``:r`` replaces any existing user ACE rather than appending).
+
+    Runs ``icacls`` out of process because the standard library has no NTFS
+    ACL API.  Failures are deliberately swallowed (best-effort, like POSIX
+    chmod) — callers still get the POSIX mode at creation time.
+    """
+    identity = _windows_identity()
+    if identity is None:
+        return
+    for args in (
+        ["icacls", os.fspath(path), "/inheritance:r"],
+        ["icacls", os.fspath(path), "/grant:r", f"{identity}:F"],
+    ):
+        try:
+            subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                encoding="mbcs",
+                errors="replace",
+                timeout=15,
+                check=True,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return  # best-effort; keep the caller moving
 
 
 def ensure_private_directory(path: Path | str) -> Path:
@@ -63,6 +125,8 @@ def open_private_file(path: Path | str, flags: int) -> int:
             )
         if os.name != "nt":
             os.fchmod(descriptor, PRIVATE_FILE_MODE)
+        else:
+            _restrict_windows_acl(target)
         return descriptor
     except BaseException:
         os.close(descriptor)
@@ -97,6 +161,8 @@ def open_existing_private_file(
             )
         if os.name != "nt":
             os.fchmod(descriptor, PRIVATE_FILE_MODE)
+        else:
+            _restrict_windows_acl(target)
         return descriptor
     except BaseException:
         os.close(descriptor)
@@ -119,8 +185,6 @@ def harden_private_tree(root: Path | str) -> Path:
     """Repair a DeepCode-owned tree while refusing to traverse symlinks."""
 
     base = ensure_private_directory(root)
-    if os.name == "nt":
-        return base
 
     for current, directories, files in os.walk(base, followlinks=False):
         current_path = Path(current)
@@ -137,6 +201,7 @@ def harden_private_tree(root: Path | str) -> Path:
 
 def _chmod(path: Path, mode: int) -> None:
     if os.name == "nt":
+        _restrict_windows_acl(path)
         return
     try:
         os.chmod(path, mode, follow_symlinks=False)

--- a/tests/test_code_indexer_output.py
+++ b/tests/test_code_indexer_output.py
@@ -1,0 +1,106 @@
+"""Regression cover for the ``output.ensure_ascii`` config flag.
+
+Three JSON-writing paths in ``tools/code_indexer.py`` used to compute
+``ensure_ascii = not output_config.get("ensure_ascii", False)`` — inverting the
+flag, so both the shipped ``ensure_ascii: false`` and the ``False`` fallback
+produced ``\\uXXXX``-escaped output. These tests pin the direction: the config
+value reaches ``json.dump`` unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.code_indexer import CodeIndexer
+
+_NON_ASCII = "工作流/代码索引.py"
+_SHIPPED_CONFIG = ROOT / "tools" / "indexer_config.yaml"
+
+_STATS_ROW = {
+    "analyzed_files": 1,
+    "total_relationships": 0,
+    "total_lines_of_code": 10,
+    "relationship_type_counts": {},
+    "file_type_counts": {_NON_ASCII: 1},
+}
+
+
+def _indexer(tmp_path: Path, *, ensure_ascii: bool | None) -> CodeIndexer:
+    """Build an indexer whose ``output.ensure_ascii`` is exactly ``ensure_ascii``.
+
+    ``None`` leaves the key absent so the in-code ``False`` fallback applies.
+    """
+
+    indexer = CodeIndexer(output_dir=str(tmp_path / "indexes"))
+    output = indexer.indexer_config.setdefault("output", {})
+    if ensure_ascii is None:
+        output.pop("ensure_ascii", None)
+    else:
+        output["ensure_ascii"] = ensure_ascii
+    return indexer
+
+
+def _write(indexer: CodeIndexer, method: str) -> str:
+    if method == "statistics":
+        return indexer.generate_statistics_report([_STATS_ROW])
+    return indexer.generate_summary_report({_NON_ASCII: "out.json"})
+
+
+def test_shipped_config_requests_literal_utf8():
+    """``tools/indexer_config.yaml`` ships ``ensure_ascii: false``."""
+
+    import yaml
+
+    shipped = yaml.safe_load(_SHIPPED_CONFIG.read_text(encoding="utf-8"))
+    assert shipped["output"]["ensure_ascii"] is False
+
+
+def test_shipped_config_is_honored_end_to_end(tmp_path):
+    indexer = CodeIndexer(
+        output_dir=str(tmp_path / "indexes"),
+        indexer_config_path=str(_SHIPPED_CONFIG),
+    )
+    assert indexer.indexer_config["output"]["ensure_ascii"] is False
+
+    raw = Path(_write(indexer, "summary")).read_text(encoding="utf-8")
+    assert _NON_ASCII in raw
+    assert "\\u" not in raw
+
+
+@pytest.mark.parametrize("method", ["statistics", "summary"])
+def test_ensure_ascii_false_writes_literal_utf8(tmp_path, method):
+    raw = Path(_write(_indexer(tmp_path, ensure_ascii=False), method)).read_text(
+        encoding="utf-8"
+    )
+    assert _NON_ASCII in raw
+    assert "\\u" not in raw
+
+
+@pytest.mark.parametrize("method", ["statistics", "summary"])
+def test_ensure_ascii_true_escapes(tmp_path, method):
+    raw = Path(_write(_indexer(tmp_path, ensure_ascii=True), method)).read_text(
+        encoding="utf-8"
+    )
+    assert _NON_ASCII not in raw
+    assert "\\u5de5\\u4f5c\\u6d41" in raw  # 工作流
+    # Still valid JSON that round-trips to the original text.
+    assert _NON_ASCII in json.dumps(json.loads(raw), ensure_ascii=False)
+
+
+@pytest.mark.parametrize("method", ["statistics", "summary"])
+def test_absent_key_defaults_to_literal_utf8(tmp_path, method):
+    """The in-code fallback is ``False`` — this is the default runtime path,
+    since ``CodeIndexer`` does not load the shipped YAML unless told to."""
+
+    raw = Path(_write(_indexer(tmp_path, ensure_ascii=None), method)).read_text(
+        encoding="utf-8"
+    )
+    assert _NON_ASCII in raw

--- a/tests/test_exec_sandbox_wiring.py
+++ b/tests/test_exec_sandbox_wiring.py
@@ -46,9 +46,9 @@ def test_disabled_via_env_returns_bare(monkeypatch, tmp_path):
 def test_enabled_by_default(monkeypatch, tmp_path):
     monkeypatch.delenv("DEEPCODE_SANDBOX", raising=False)
     w = build_exec_command(command="echo hi", workspace=tmp_path)
-    # backend is seatbelt/bwrap on supported platforms, else "none" — never
+    # backend is seatbelt/bwrap/job on supported platforms, else "none" — never
     # "disabled" (which only happens when explicitly turned off).
-    assert w.backend in ("seatbelt", "bwrap", "none")
+    assert w.backend in ("seatbelt", "bwrap", "job", "none")
 
 
 def test_explicit_frozen_sandbox_value_beats_environment(monkeypatch, tmp_path):
@@ -66,7 +66,7 @@ def test_explicit_frozen_sandbox_value_beats_environment(monkeypatch, tmp_path):
         workspace=tmp_path,
         enabled=True,
     )
-    assert enabled.backend in ("seatbelt", "bwrap", "none")
+    assert enabled.backend in ("seatbelt", "bwrap", "job", "none")
     assert enabled.backend != "disabled"
 
 

--- a/tests/test_harness_sandbox.py
+++ b/tests/test_harness_sandbox.py
@@ -23,6 +23,7 @@ from core.harness.sandbox import (  # noqa: E402
     _seatbelt_profile,
     wrap_shell_command,
 )
+from core.harness.windows_sandbox import _run_in_job  # noqa: E402
 
 
 def test_policy_for_workspace_normalizes_root(tmp_path):
@@ -35,9 +36,10 @@ def test_wrap_returns_runnable_argv(tmp_path):
     policy = SandboxPolicy.for_workspace(tmp_path)
     wrapped = wrap_shell_command("echo hi", policy)
     assert wrapped.argv[-2:] == ["-c", "echo hi"]
-    assert wrapped.backend in ("seatbelt", "bwrap", "none")
+    assert wrapped.backend in ("seatbelt", "bwrap", "job", "none")
 
 
+@pytest.mark.skipif(platform.system() != "Darwin", reason="seatbelt policy is macOS-only")
 def test_seatbelt_profile_is_deny_default_and_grants_workspace_writes(tmp_path):
     policy = SandboxPolicy.for_workspace(tmp_path)
     profile = _seatbelt_profile(policy)
@@ -52,6 +54,7 @@ def test_seatbelt_profile_is_deny_default_and_grants_workspace_writes(tmp_path):
     assert "network-outbound" not in profile
 
 
+@pytest.mark.skipif(platform.system() != "Darwin", reason="seatbelt policy is macOS-only")
 def test_seatbelt_profile_network_toggle(tmp_path):
     policy = SandboxPolicy.for_workspace(tmp_path, allow_network=True)
     # Network is re-granted only when the policy allows it.
@@ -122,3 +125,43 @@ def test_seatbelt_allows_reads_everywhere(tmp_path):
         wrapped.cleanup()
     assert proc.returncode == 0
     assert proc.stdout.decode().strip() == "hello"
+
+
+# ---- Windows Job Object backend ------------------------------------------
+
+_job = platform.system() == "Windows"
+
+
+@pytest.mark.skipif(not _job, reason="Windows Job Object backend only")
+def test_windows_job_runs_and_forwards_exit_code():
+    code = "import sys; sys.exit(7)"
+    exit_code = _run_in_job([sys.executable, "-c", code])
+    assert exit_code == 7
+
+
+@pytest.mark.skipif(not _job, reason="Windows Job Object backend only")
+def test_windows_job_wrapper_is_used_by_build_exec_command(tmp_path):
+    from core.harness.sandbox import build_exec_command
+
+    wrapped = build_exec_command(
+        argv=[sys.executable, "-c", "pass"],
+        workspace=tmp_path,
+        allow_network=False,
+    )
+    # The wrapper module must prefix the inner argv.
+    assert "core.harness.windows_sandbox" in wrapped.argv
+    assert wrapped.backend == "job"
+
+
+@pytest.mark.skipif(not _job, reason="Windows Job Object backend only")
+def test_windows_job_kills_descendant_processes():
+    """KILL_ON_JOB_CLOSE: a background child spawned by the inner command must
+    not outlive the wrapper (no orphaned process escapes the job)."""
+    probe = sys.executable
+    code = (
+        "import subprocess, sys, time\n"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])\n"
+        "print(child.pid, flush=True)\n"
+    )
+    exit_code = _run_in_job([probe, "-c", code])
+    assert exit_code == 0

--- a/tests/test_harness_sandbox.py
+++ b/tests/test_harness_sandbox.py
@@ -21,6 +21,7 @@ if str(ROOT) not in sys.path:
 from core.harness.sandbox import (  # noqa: E402
     SandboxPolicy,
     _seatbelt_profile,
+    fences_writes,
     wrap_shell_command,
 )
 from core.harness.windows_sandbox import _run_in_job  # noqa: E402
@@ -39,7 +40,9 @@ def test_wrap_returns_runnable_argv(tmp_path):
     assert wrapped.backend in ("seatbelt", "bwrap", "job", "none")
 
 
-@pytest.mark.skipif(platform.system() != "Darwin", reason="seatbelt policy is macOS-only")
+@pytest.mark.skipif(
+    platform.system() != "Darwin", reason="seatbelt policy is macOS-only"
+)
 def test_seatbelt_profile_is_deny_default_and_grants_workspace_writes(tmp_path):
     policy = SandboxPolicy.for_workspace(tmp_path)
     profile = _seatbelt_profile(policy)
@@ -54,7 +57,9 @@ def test_seatbelt_profile_is_deny_default_and_grants_workspace_writes(tmp_path):
     assert "network-outbound" not in profile
 
 
-@pytest.mark.skipif(platform.system() != "Darwin", reason="seatbelt policy is macOS-only")
+@pytest.mark.skipif(
+    platform.system() != "Darwin", reason="seatbelt policy is macOS-only"
+)
 def test_seatbelt_profile_network_toggle(tmp_path):
     policy = SandboxPolicy.for_workspace(tmp_path, allow_network=True)
     # Network is re-granted only when the policy allows it.
@@ -68,6 +73,22 @@ def test_none_backend_is_flagged(monkeypatch, tmp_path):
     wrapped = wrap_shell_command("echo hi", SandboxPolicy.for_workspace(tmp_path))
     assert wrapped.backend == "none"
     assert wrapped.argv == ["/bin/bash", "-c", "echo hi"]
+
+
+@pytest.mark.parametrize(
+    ("backend", "fenced"),
+    [
+        ("seatbelt", True),
+        ("bwrap", True),
+        # The Job Object isolates the process tree but leaves the filesystem
+        # open, so callers must not advertise a write-fence on Windows.
+        ("job", False),
+        ("none", False),
+    ],
+)
+def test_fences_writes_tracks_backend_capability(monkeypatch, backend, fenced):
+    monkeypatch.setattr("core.harness.sandbox.sandbox_backend", lambda: backend)
+    assert fences_writes() is fenced
 
 
 # ---- real enforcement smoke (macOS only) -----------------------------------

--- a/tests/test_private_storage_windows.py
+++ b/tests/test_private_storage_windows.py
@@ -1,0 +1,94 @@
+"""Windows ACL tests for ``core.private_storage``.
+
+POSIX-mode assertions live in ``test_private_storage.py`` (skipped on
+Windows).  On Windows the equivalent guarantee is a *restricted NTFS ACL*:
+inherited ACEs such as ``Authenticated Users`` and ``BUILTIN\\Users`` are
+removed and only the current user keeps full control.
+
+These tests run on Windows only; on POSIX the helpers are no-ops and the
+assertions below are skipped.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.private_storage import ensure_private_directory, open_private_file
+
+pytestmark = pytest.mark.skipif(
+    os.name != "nt",
+    reason="NTFS ACL restriction applies on Windows only",
+)
+
+# ACEs that must never survive on a private DeepCode path.
+_DANGEROUS_ACES = (
+    "Authenticated Users",
+    "BUILTIN\\Users",
+    "Everyone",
+)
+
+# System-level ACEs that icacls keeps by design and are safe to ignore.
+_SAFE_ACES = (
+    "NT AUTHORITY\\SYSTEM",
+    "BUILTIN\\Administrators",
+    "OWNER RIGHTS",
+    "CREATOR OWNER",
+)
+
+
+def _acl_lines(path: Path) -> list[str]:
+    completed = subprocess.run(
+        ["icacls", os.fspath(path)],
+        capture_output=True,
+        text=True,
+        encoding="mbcs",
+        errors="replace",
+        check=False,
+    )
+    return [
+        line.strip() for line in (completed.stdout or "").splitlines() if ":" in line
+    ]
+
+
+def _assert_no_dangerous_aces(path: Path) -> None:
+    lines = _acl_lines(path)
+    assert lines, f"icacls returned no ACE lines for {path}"
+    for line in lines:
+        for ace in _DANGEROUS_ACES:
+            assert ace not in line, (
+                f"{path} still exposes dangerous ACE '{ace}': {line}"
+            )
+
+
+def test_windows_private_directory_is_restricted(tmp_path: Path) -> None:
+    private = tmp_path / "home" / "sessions"
+    ensure_private_directory(private)
+    _assert_no_dangerous_aces(private)
+
+
+def test_windows_private_file_is_restricted(tmp_path: Path) -> None:
+    private = tmp_path / "home"
+    ensure_private_directory(private)
+    fd = open_private_file(private / "credentials.json", os.O_CREAT | os.O_WRONLY)
+    os.close(fd)
+    _assert_no_dangerous_aces(private / "credentials.json")
+
+
+def test_windows_restriction_keeps_current_user(tmp_path: Path) -> None:
+    private = tmp_path / "home"
+    ensure_private_directory(private)
+    fd = open_private_file(private / "secret.bin", os.O_CREAT | os.O_WRONLY)
+    os.close(fd)
+    lines = _acl_lines(private / "secret.bin")
+    # icacls prints the current principal as DOMAIN\user with (F) full control;
+    # the exact DOMAIN prefix varies (machine name vs. domain), so accept any
+    # ACE granting full control that is not a system-level ACE.
+    for line in lines:
+        principal = line.split(":")[0]
+        if ":(" in line and "(F)" in line and principal not in _SAFE_ACES:
+            return  # found a full-control grant for a non-system principal
+    pytest.fail(f"no current-user full-control grant found in: {lines!r}")

--- a/tools/code_implementation_server.py
+++ b/tools/code_implementation_server.py
@@ -29,7 +29,7 @@ from core.platform_compat import (
     subprocess_env,
     subprocess_text_kwargs,
 )
-from core.harness.sandbox import build_exec_command, describe_backend
+from core.harness.sandbox import build_exec_command, describe_backend, fences_writes
 
 configure_utf8_stdio()
 
@@ -1434,8 +1434,11 @@ async def set_workspace(workspace_path: str) -> str:
 
         logger.info(f"New Workspace: {WORKSPACE_DIR}")
         logger.info(
-            "Command execution sandbox: %s (writes fenced to workspace)",
+            "Command execution sandbox: %s (%s)",
             describe_backend(),
+            "writes fenced to workspace"
+            if fences_writes()
+            else "writes NOT fenced to workspace",
         )
 
         result = {

--- a/tools/code_indexer.py
+++ b/tools/code_indexer.py
@@ -1128,7 +1128,7 @@ class CodeIndexer:
                 # Get output configuration
                 output_config = self.indexer_config.get("output", {})
                 json_indent = output_config.get("json_indent", 2)
-                ensure_ascii = not output_config.get("ensure_ascii", False)
+                ensure_ascii = output_config.get("ensure_ascii", False)
 
                 # Save to JSON file
                 with open(output_file, "w", encoding="utf-8") as f:
@@ -1322,7 +1322,7 @@ class CodeIndexer:
         # Get output configuration
         output_config = self.indexer_config.get("output", {})
         json_indent = output_config.get("json_indent", 2)
-        ensure_ascii = not output_config.get("ensure_ascii", False)
+        ensure_ascii = output_config.get("ensure_ascii", False)
 
         with open(stats_path, "w", encoding="utf-8") as f:
             json.dump(
@@ -1338,7 +1338,7 @@ class CodeIndexer:
         # Get output configuration from config file
         output_config = self.indexer_config.get("output", {})
         json_indent = output_config.get("json_indent", 2)
-        ensure_ascii = not output_config.get("ensure_ascii", False)
+        ensure_ascii = output_config.get("ensure_ascii", False)
 
         summary_data = {
             "indexing_completion_time": datetime.now().isoformat(),


### PR DESCRIPTION
## Description

Lands the three open PRs that still apply to `main` after the v2.0 refactor, with original authorship preserved via cherry-pick.

| commit | author | source |
|---|---|---|
| `8f9999c` | @Osamaali313 | #139 |
| `9e4b2c8` | @raymondginger2018-sudo | #149 |
| `576ed69` | @raymondginger2018-sudo | #148 |

The remaining commits are follow-on work found while verifying the above.

## Changes

**#139 — `ensure_ascii` config was inverted** (`tools/code_indexer.py`)

Three JSON-writing paths computed `ensure_ascii = not output_config.get("ensure_ascii", False)`. `tools/indexer_config.yaml` ships `ensure_ascii: false`, and `codebase_index_workflow.load_or_create_indexer_config()` loads it — so every index/statistics/summary JSON escaped non-ASCII to `\uXXXX` against the config's explicit intent. Added 8 regression tests pinning the direction; reverting the fix fails 7 of them.

**#149 — Windows had no sandbox backend** (`core/harness/sandbox.py`, `core/harness/windows_sandbox.py`)

`sandbox_backend()` returned `"none"` on Windows, and `wrap_argv_command()` returned the argv unwrapped — so `core/harness/tools/shell.py` and `core/harness/code_mode/tool.py` ran with no isolation. Adds a Job Object backend with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` for process-tree isolation. It does not fake a write-fence; that boundary is documented.

**#148 — Windows private files inherited the profile ACL** (`core/private_storage.py`)

Every Windows path in this module was a no-op, so `credentials.json` and other private state inherited the profile ACL (`Authenticated Users` typically gets Modify) instead of the POSIX `0600` equivalent. Now removes inheritance and grants the current user exclusive access via `icacls`, best-effort like POSIX `chmod`.

Rebase note: `main` gained `open_existing_private_file()` after this patch was written, and the three-way merge attached the ACL call to that new function instead of `open_private_file()`. Both now restrict the ACL, matching the POSIX path where each repairs the mode on its own descriptor.

**CI — the Windows-gated suites never ran**

`windows-lifecycle` ran four named lifecycle files; the ubuntu job runs everything but can only skip Windows-gated cases. The NTFS ACL and Job Object tests had no enforcement point anywhere — six cases that never executed. The Windows job now runs them.

**Sandbox log — claimed a write-fence the backend does not provide**

`tools/code_implementation_server.py` hardcoded `"(writes fenced to workspace)"` regardless of backend. Derived from `fences_writes()` instead.

## Testing

- Full suite: **1131 passed / 6 skipped / 0 failed**, two consecutive runs (`main` baseline: 1119 passed)
- `pre-commit run --from-ref origin/main --to-ref HEAD` — clean, including `actionlint`
- #139 regression tests verified in reverse: reverting the fix fails 7 of 8

**Not verified locally:** the Windows ACL behaviour — all three of its cases skip off Windows. The `windows-2022` job added here is their first real execution.

## Related Issues

Supersedes #139, #148, #149 — cherry-picked, so the SHAs differ and GitHub will not auto-close them. They should be closed manually referencing the commits above.
