### PR TITLE
docs: add CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,64 @@
+# Contributors
+
+DeepCode is built by the community. Thank you to everyone listed here.
+
+The GitHub [contributors graph](https://github.com/HKUDS/DeepCode/graphs/contributors) only
+counts commits that landed on `main`. This file is broader on purpose: it also records the
+people who opened pull requests, reported problems, and pushed the project forward in ways
+the graph cannot see.
+
+## Maintainers
+
+- [@Zongwei9888](https://github.com/Zongwei9888)
+- [@LZH-YS1998](https://github.com/LZH-YS1998)
+- [@LarFii](https://github.com/LarFii)
+
+## Code contributors
+
+People with commits on `main`.
+
+- [@chaohuang-ai](https://github.com/chaohuang-ai)
+- [@Jany-M](https://github.com/Jany-M)
+- [@AAG81](https://github.com/AAG81)
+- [@curator-me](https://github.com/curator-me)
+- [@clankwright](https://github.com/clankwright)
+- [@Osamaali313](https://github.com/Osamaali313) — fixed the inverted `ensure_ascii` config flag in the code indexer ([#139](https://github.com/HKUDS/DeepCode/pull/139))
+- [@raymondginger2018-sudo](https://github.com/raymondginger2018-sudo) — Windows Job Object sandbox backend and NTFS ACL hardening for private storage ([#149](https://github.com/HKUDS/DeepCode/pull/149), [#148](https://github.com/HKUDS/DeepCode/pull/148))
+
+## Pull request authors
+
+Everyone who has opened a pull request against DeepCode.
+
+Some of these landed as-is. Some were rebuilt on top of the v2.0 architecture, which removed
+the `nanobot/` and `new_ui/` trees a contribution may have targeted. Some identified real
+problems that were fixed independently before the PR could be merged — that work still
+mattered, and it is recorded here.
+
+| Contributor | Pull request(s) |
+|---|---|
+| [@muhammadibrahim313](https://github.com/muhammadibrahim313) | [#14](https://github.com/HKUDS/DeepCode/pull/14) |
+| [@User1234608](https://github.com/User1234608) | [#20](https://github.com/HKUDS/DeepCode/pull/20) |
+| [@lindomar8](https://github.com/lindomar8) | [#21](https://github.com/HKUDS/DeepCode/pull/21) |
+| [@PacoMortal](https://github.com/PacoMortal) | [#23](https://github.com/HKUDS/DeepCode/pull/23) |
+| [@Mirza-Samad-Ahmed-Baig](https://github.com/Mirza-Samad-Ahmed-Baig) | [#27](https://github.com/HKUDS/DeepCode/pull/27) |
+| [@brucezo](https://github.com/brucezo) | [#46](https://github.com/HKUDS/DeepCode/pull/46) |
+| [@dingdinglz](https://github.com/dingdinglz) | [#48](https://github.com/HKUDS/DeepCode/pull/48) |
+| [@VinodHatti-AI-Developer](https://github.com/VinodHatti-AI-Developer) | [#49](https://github.com/HKUDS/DeepCode/pull/49) |
+| [@Yiiii0](https://github.com/Yiiii0) | [#116](https://github.com/HKUDS/DeepCode/pull/116) |
+| [@crsmillan](https://github.com/crsmillan) | [#119](https://github.com/HKUDS/DeepCode/pull/119) |
+| [@octo-patch](https://github.com/octo-patch) | [#130](https://github.com/HKUDS/DeepCode/pull/130) |
+| [@yuefengw](https://github.com/yuefengw) | [#131](https://github.com/HKUDS/DeepCode/pull/131) |
+| [@mrluanma](https://github.com/mrluanma) | [#133](https://github.com/HKUDS/DeepCode/pull/133) |
+| [@AAtomical](https://github.com/AAtomical) | [#135](https://github.com/HKUDS/DeepCode/pull/135) |
+| [@Thibaultjaigu](https://github.com/Thibaultjaigu) | [#138](https://github.com/HKUDS/DeepCode/pull/138) |
+| [@Osamaali313](https://github.com/Osamaali313) | [#139](https://github.com/HKUDS/DeepCode/pull/139) |
+| [@raymondginger2018-sudo](https://github.com/raymondginger2018-sudo) | [#141](https://github.com/HKUDS/DeepCode/pull/141), [#143](https://github.com/HKUDS/DeepCode/pull/143), [#144](https://github.com/HKUDS/DeepCode/pull/144), [#146](https://github.com/HKUDS/DeepCode/pull/146), [#148](https://github.com/HKUDS/DeepCode/pull/148), [#149](https://github.com/HKUDS/DeepCode/pull/149) |
+
+## Adding yourself
+
+Open a pull request. If it lands, a maintainer adds you here — or add yourself in the same PR.
+
+When a maintainer ports your work rather than merging your branch directly (common when a
+contribution targets a tree that has since been restructured), the commit carries a
+`Co-authored-by:` trailer with your address, so the contributors graph still credits you.
+For that to work, the email must be one that is registered with your GitHub account.


### PR DESCRIPTION
## Description

Adds a `CONTRIBUTORS.md` recognising everyone who has contributed to DeepCode.

The GitHub contributors graph only counts commits that reached `main`. That leaves out two groups the project actually owes credit to:

- contributors whose pull request targeted `nanobot/` or `new_ui/` — trees the v2.0 refactor removed, so their branch can no longer merge as-is
- contributors who identified a real problem that was fixed independently before their branch could land

Both are recorded here alongside the code contributors.

## Structure

- **Maintainers**
- **Code contributors** — people with commits on `main`
- **Pull request authors** — all 17 people who have opened a PR, with links

## Note

The file also documents the `Co-authored-by:` convention for when a maintainer ports a contribution rather than merging the branch directly — including the requirement that the address be one registered with the author GitHub account, which is what makes the graph credit them.

Entries for @Osamaali313 and @raymondginger2018-sudo under *Code contributors* assume #156 lands first.