### PR TITLE
fix(security): allowlist the #131 test fixture in gitleaks history

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -5,3 +5,10 @@
 b2dccbe6d37e74e98b8a57593c1a5bb4994fba59:mcp_agent.secrets.yaml:generic-api-key:9
 420d07580e83885cdf784115131aea884e704a8f:mcp_agent.secrets.yaml:generic-api-key:2
 225e344437173185f22f30cbac58fc82f9fbe3ed:mcp_agent.secrets.yaml:generic-api-key:2
+
+# Test fixture, not a credential: the literal "sk-secret123456" inside a
+# RuntimeError message, used to assert that error text is redacted before it
+# reaches the UI. It arrived with the #131 merge, which recorded the branch in
+# history without applying its tree — so the file does not exist on main and
+# the finding cannot be fixed by editing it.
+6421db9a2fb04589200f8883f950a329b7ced1cd:tests/ui_session_resume_test.py:generic-api-key:87


### PR DESCRIPTION
## Why

The **Secret history scan** has failed on `main` since `dd8f0a8`. The step is named "Install pinned Gitleaks", but its last line is the scan itself:

```yaml
./gitleaks git --redact --no-banner --exit-code 1
```

so an install-shaped failure was actually `leaks found: 1`. The download and checksum were fine (`gitleaks.tar.gz: OK`).

## Cause

`dd8f0a8` merged ten stale pull requests with `-s ours` to record their authors as contributors. That strategy leaves the tree untouched — but it does make each branch's commits ancestors of `main`, and **gitleaks scans history, not the working tree**.

One of them, #131, contains a finding.

## The finding

`tests/ui_session_resume_test.py:87`, from commit `6421db9a`:

```python
RuntimeError(
    "Workflow execution failed: <html><h1>504 Gateway Time-out</h1></html> api_key=sk-secret123456"
)
```

A fixture, not a credential: the literal `sk-secret123456` exists to assert that error text is redacted before it reaches the UI. Nothing to rotate.

The file does not exist on `main` — the `-s ours` merge never applied its tree — so the finding cannot be fixed by editing it. A fingerprint entry is the only route.

## Verification

```
gitleaks git --log-opts=origin/main
  240 commits scanned.
  no leaks found
```

## Worth recording for next time

`-s ours` merges bring the branch's whole history under the secret scan. Two branches deliberately left unmerged carry findings of their own — and **#133's is a real key**, not a fixture. Merging those for attribution alone would have put a live credential in `main`'s history permanently, where only a rewrite could remove it.
