### PR TITLE
fix(providers): gate thinking on model capability; add an installed-font picker

### DIFF
--- a/core/providers/model_compat.py
+++ b/core/providers/model_compat.py
@@ -60,6 +60,23 @@ def is_reasoning_model(model_name: str) -> bool:
     return any(token in name for token in _REASONING_MODEL_TOKENS)
 
 
+def model_supports_thinking(model_name: str) -> bool:
+    """Whether the model itself has a thinking mode, per the catalog.
+
+    Distinct from :func:`is_reasoning_model`, which asks the narrower question
+    "does this model reject a temperature while reasoning". This one gates the
+    provider's thinking body, so it must follow the catalog rather than a
+    token list: a model absent from it has no advertised thinking mode and
+    must not be sent one.
+    """
+
+    # Imported inside the call: the catalog reaches this module's sibling
+    # ``reasoning`` at import time.
+    from core.providers.catalog import resolve_model_info
+
+    return resolve_model_info(model_name).reasoning is not None
+
+
 def is_kimi_thinking_model(model_name: str) -> bool:
     name = model_name.lower()
     return (
@@ -141,8 +158,17 @@ def resolve_model_compat(
     thinking_enabled = reasoning_active
 
     # Thinking extra_body: provider-level style OR model-level Kimi injection.
+    #
+    # ``thinking_style`` says how *this endpoint* spells a thinking toggle; it
+    # says nothing about whether the model behind it has one. Those are
+    # separate axes, and applying the style on the provider alone sent a
+    # thinking body to models with no thinking mode — a gpt-4o request routed
+    # through a Zhipu- or DeepSeek-compatible endpoint would carry
+    # ``thinking: {"type": "enabled"}``. Require both.
     thinking_extra_body: dict[str, Any] | None = None
     style = getattr(spec, "thinking_style", "") if spec is not None else ""
+    if style and not model_supports_thinking(resolved_name):
+        style = ""
     if style and semantic_effort not in {None, "auto"}:
         builder = _THINKING_STYLE_BUILDERS.get(style)
         if builder is not None:

--- a/desktop/src/app/fontCandidates.test.ts
+++ b/desktop/src/app/fontCandidates.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  appendFamily,
+  availableFontCandidates,
+  FONT_CANDIDATES,
+  isFontAvailable,
+} from "./fontCandidates";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(document, "fonts");
+});
+
+function stubFonts(installed: string[]): void {
+  Object.defineProperty(document, "fonts", {
+    configurable: true,
+    value: {
+      check: (font: string) =>
+        installed.some((family) => font.includes(`"${family}"`)),
+    },
+  });
+}
+
+describe("isFontAvailable", () => {
+  it("reports nothing when the Font Loading API is absent", () => {
+    // jsdom and older WebViews have no document.fonts. Claiming every family
+    // exists there would offer the user settings that do nothing.
+    Reflect.deleteProperty(document, "fonts");
+    expect(isFontAvailable("Inter")).toBe(false);
+  });
+
+  it("asks the document rather than guessing", () => {
+    stubFonts(["Inter"]);
+    expect(isFontAvailable("Inter")).toBe(true);
+    expect(isFontAvailable("Definitely Not Installed")).toBe(false);
+  });
+
+  it("survives a family name that would break the shorthand", () => {
+    Object.defineProperty(document, "fonts", {
+      configurable: true,
+      value: {
+        check: () => {
+          throw new SyntaxError("bad font shorthand");
+        },
+      },
+    });
+    expect(isFontAvailable('bro"ken')).toBe(false);
+  });
+});
+
+describe("availableFontCandidates", () => {
+  it("offers only what is installed", () => {
+    stubFonts(["Inter", "PingFang SC"]);
+    expect(availableFontCandidates().map((c) => c.family)).toEqual([
+      "Inter",
+      "PingFang SC",
+    ]);
+  });
+
+  it("returns nothing rather than the whole list when probing is impossible", () => {
+    Reflect.deleteProperty(document, "fonts");
+    expect(availableFontCandidates()).toEqual([]);
+  });
+
+  it("covers each group so the picker is useful on any platform", () => {
+    const groups = new Set(FONT_CANDIDATES.map((c) => c.group));
+    expect(groups).toEqual(new Set(["Interface", "Monospace", "CJK"]));
+  });
+});
+
+describe("appendFamily", () => {
+  it("adds to an empty list", () => {
+    expect(appendFamily("", "Inter")).toBe("Inter");
+  });
+
+  it("appends without disturbing existing entries", () => {
+    expect(appendFamily("Inter", "PingFang SC")).toBe("Inter, PingFang SC");
+  });
+
+  it("ignores a family already present, whatever its case", () => {
+    expect(appendFamily("Inter, PingFang SC", "inter")).toBe(
+      "Inter, PingFang SC",
+    );
+  });
+
+  it("tidies stray separators from hand-typed input", () => {
+    expect(appendFamily("Inter,  , ", "Roboto")).toBe("Inter, Roboto");
+  });
+});

--- a/desktop/src/app/fontCandidates.ts
+++ b/desktop/src/app/fontCandidates.ts
@@ -1,0 +1,74 @@
+/**
+ * Font suggestions filtered to what the machine actually has.
+ *
+ * A plain dropdown of font names would be a hardcoded guess: the list that is
+ * right on a Windows box with Microsoft YaHei is wrong on a Mac with PingFang,
+ * and offering a family the system lacks produces a setting that silently does
+ * nothing. `document.fonts.check()` answers the question directly, so the
+ * candidates below are only ever *suggestions* — the UI shows the survivors
+ * and still accepts free text for anything not listed.
+ */
+
+export interface FontCandidate {
+  family: string;
+  /** Grouping for the UI; also documents why each family is here. */
+  group: "Interface" | "Monospace" | "CJK";
+}
+
+/**
+ * Families worth offering when present. Deliberately broad and cross-platform
+ * — an entry that is missing costs nothing because it is filtered out.
+ */
+export const FONT_CANDIDATES: readonly FontCandidate[] = [
+  { family: "Inter", group: "Interface" },
+  { family: "Segoe UI Variable", group: "Interface" },
+  { family: "Segoe UI", group: "Interface" },
+  { family: "SF Pro Text", group: "Interface" },
+  { family: "Helvetica Neue", group: "Interface" },
+  { family: "Roboto", group: "Interface" },
+  { family: "JetBrains Mono", group: "Monospace" },
+  { family: "Cascadia Code", group: "Monospace" },
+  { family: "Fira Code", group: "Monospace" },
+  { family: "SFMono-Regular", group: "Monospace" },
+  { family: "Consolas", group: "Monospace" },
+  { family: "Microsoft YaHei", group: "CJK" },
+  { family: "PingFang SC", group: "CJK" },
+  { family: "Noto Sans SC", group: "CJK" },
+  { family: "Source Han Sans SC", group: "CJK" },
+  { family: "Sarasa Mono SC", group: "CJK" },
+  { family: "Hiragino Sans GB", group: "CJK" },
+];
+
+/**
+ * Whether `family` resolves on this machine.
+ *
+ * `document.fonts.check` needs a full font shorthand and throws on a malformed
+ * one, so the family is quoted and the call is guarded. An environment without
+ * the Font Loading API (jsdom, an old WebView) reports nothing rather than
+ * pretending every family exists.
+ */
+export function isFontAvailable(family: string): boolean {
+  if (typeof document === "undefined" || !document.fonts?.check) return false;
+  try {
+    return document.fonts.check(`12px "${family.replaceAll('"', "")}"`);
+  } catch {
+    return false;
+  }
+}
+
+/** The candidates present on this machine, in declaration order. */
+export function availableFontCandidates(): FontCandidate[] {
+  return FONT_CANDIDATES.filter((candidate) => isFontAvailable(candidate.family));
+}
+
+/** Append `family` to a comma-separated list, ignoring duplicates. */
+export function appendFamily(current: string, family: string): string {
+  const families = current
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (families.some((entry) => entry.toLowerCase() === family.toLowerCase())) {
+    return current;
+  }
+  return [...families, family].join(", ");
+}

--- a/desktop/src/features/settings/AppearanceSettings.tsx
+++ b/desktop/src/features/settings/AppearanceSettings.tsx
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import { useMemo, useId } from "react";
 
 import {
   APPEARANCE_DEFAULTS,
@@ -7,6 +7,10 @@ import {
   type AppearanceState,
   type ThemePreference,
 } from "../../app/appearance";
+import {
+  appendFamily,
+  availableFontCandidates,
+} from "../../app/fontCandidates";
 import { useAppearance } from "../../app/useAppearance";
 import styles from "../management/ManagementWorkspace.module.css";
 
@@ -27,6 +31,9 @@ const THEME_LABELS: Record<ThemePreference, string> = {
 export function AppearanceSettings() {
   const { appearance, set, reset } = useAppearance();
   const fieldId = useId();
+  // Probed once per mount: the set of installed fonts does not change while
+  // the settings page is open.
+  const installed = useMemo(() => availableFontCandidates(), []);
   const isDefault = APPEARANCE_SETTINGS.every(
     (setting) => appearance[setting.key] === APPEARANCE_DEFAULTS[setting.key],
   );
@@ -105,6 +112,39 @@ export function AppearanceSettings() {
                   set(setting.key as "fontFamily", event.target.value)
                 }
               />
+              {installed.length > 0 ? (
+                <select
+                  aria-label="Add an installed font"
+                  value=""
+                  onChange={(event) => {
+                    if (!event.target.value) return;
+                    set(
+                      "fontFamily",
+                      appendFamily(appearance.fontFamily, event.target.value),
+                    );
+                  }}
+                >
+                  <option value="">Add an installed font…</option>
+                  {["Interface", "Monospace", "CJK"].map((group) => {
+                    const members = installed.filter(
+                      (candidate) => candidate.group === group,
+                    );
+                    if (members.length === 0) return null;
+                    return (
+                      <optgroup key={group} label={group}>
+                        {members.map((candidate) => (
+                          <option
+                            key={candidate.family}
+                            value={candidate.family}
+                          >
+                            {candidate.family}
+                          </option>
+                        ))}
+                      </optgroup>
+                    );
+                  })}
+                </select>
+              ) : null}
             </label>
           );
         })}

--- a/tests/test_thinking_requires_capable_model.py
+++ b/tests/test_thinking_requires_capable_model.py
@@ -1,0 +1,86 @@
+"""A thinking body needs both a capable model and an endpoint that spells it.
+
+``ProviderSpec.thinking_style`` describes the *endpoint's dialect* — how this
+API writes a thinking toggle. It says nothing about whether the model behind
+it has one. Applying it on the provider alone meant a model with no thinking
+mode still received ``thinking: {"type": "enabled"}`` whenever it happened to
+be routed through DeepSeek- or Zhipu-compatible endpoint.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.providers.model_compat import (  # noqa: E402
+    model_supports_thinking,
+    resolve_model_compat,
+)
+from core.providers.registry import find_by_name  # noqa: E402
+
+# Every provider that declares a thinking dialect.
+THINKING_ENDPOINTS = ["deepseek", "zhipu", "dashscope"]
+
+
+@pytest.mark.parametrize("provider", THINKING_ENDPOINTS)
+@pytest.mark.parametrize("model", ["gpt-4o", "gpt-4o-mini", "llama3", "kimi-k2"])
+def test_models_without_a_thinking_mode_are_never_sent_one(
+    provider: str, model: str
+) -> None:
+    compat = resolve_model_compat(
+        model_name=model,
+        spec=find_by_name(provider),
+        reasoning_effort="high",
+    )
+    assert compat.thinking_extra_body is None
+    # The echo exists to pair with a thinking turn; without one it is noise.
+    assert compat.inject_empty_reasoning_content is False
+
+
+@pytest.mark.parametrize("provider", THINKING_ENDPOINTS)
+@pytest.mark.parametrize("model", ["deepseek-chat", "glm-4.6", "qwen3-max"])
+def test_capable_models_still_get_the_endpoint_dialect(
+    provider: str, model: str
+) -> None:
+    """The gate narrows by model; it must not disable the feature."""
+
+    compat = resolve_model_compat(
+        model_name=model,
+        spec=find_by_name(provider),
+        reasoning_effort="high",
+    )
+    assert compat.thinking_extra_body is not None
+
+
+def test_an_endpoint_without_a_dialect_sends_nothing() -> None:
+    """Capability alone is not enough — the endpoint must spell it too."""
+
+    compat = resolve_model_compat(
+        model_name="deepseek-chat",
+        spec=find_by_name("openai"),
+        reasoning_effort="high",
+    )
+    assert compat.thinking_extra_body is None
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("deepseek-chat", True),
+        ("deepseek-r2", True),  # unseen; inherits the deepseek-r family row
+        ("glm-4.7", True),  # unseen; inherits the glm family row
+        ("claude-sonnet-5", True),
+        ("gpt-4o", False),
+        ("llama3", False),
+    ],
+)
+def test_capability_follows_the_catalog_not_a_token_list(
+    model: str, expected: bool
+) -> None:
+    assert model_supports_thinking(model) is expected


### PR DESCRIPTION
## Description

Two follow-ups to #161: one fixes a bug that PR widened, the other delivers the part of #155 it declined.

## A thinking body reaching models that have no thinking mode

`ProviderSpec.thinking_style` describes the **endpoint's dialect** — how this API spells a thinking toggle. It says nothing about whether the model behind it has one, and the two were never intersected. Any model routed through a DeepSeek- or Zhipu-compatible endpoint received:

```json
{"thinking": {"type": "enabled"}}
```

including `gpt-4o` and `llama3`. The empty `reasoning_content` echo rode along with it.

Pre-existing, but **#161 widened it** by giving Zhipu a style, so it is not waiting for a larger cleanup. Both halves of the answer now live in one place — the catalog knows whether the model thinks, the spec knows how the endpoint writes it — and the style applies only when both agree.

Deliberately *not* narrowed to a vendor. A capable model reached through an endpoint that speaks a given dialect should get that dialect: `gpt-5.4` behind a DeepSeek-compatible gateway still gets the DeepSeek body, because that is the endpoint's contract, not a claim about who built the model.

## The font picker #155 actually asked for

#161 shipped a free-text field and argued a fixed dropdown would be a hardcoded guess about the user's machine. The premise was right; the conclusion was not — the browser can be asked.

`document.fonts.check()` reports whether a family resolves locally, so the candidate list is filtered to what is installed and grouped Interface / Monospace / CJK. Selecting one *appends* to the field rather than replacing it, which keeps the mixed-script case from #155 working: list the CJK face next to the Latin one and both render through a single fallback chain.

Free text stays the source of truth, so families outside the candidate list remain reachable, and where the Font Loading API is absent the picker hides rather than offering settings that would do nothing.

## Testing

- Python: **1218 passed, 3 skipped**
- Desktop: **148 passed across 24 files**; `tsc --noEmit`, `eslint`, `npm run build` clean
- The thinking gate is verified in reverse — removing it fails 12 of the 28 new cases

## Still open from the same investigation

- `AgentDefaults.context_window_tokens` is dead config on the modern path. Nothing outside `core/compat/` reads it; the runner takes its window from `ExecutionProfile`, which comes from the catalog. Setting it in `deepcode_config.json` has no effect today, which matters for the context-length half of #153.
- `tests/application/test_automation_goal_runs.py::test_legacy_unreserved_turn_is_never_adopted_as_automation_initial_turn` fails ~2/20 on clean `main`, unrelated to this work.
