### PR TITLE
docs: add 2026-08-07 news entry and an Appreciation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Skills, permissions, Goals, and Automations. See the
 - [🎬 Live demonstrations](#live-demonstrations)
 - [🛠️ Development](#development)
 - [⭐ Star History](#star-history)
+- [🙏 Appreciation](#contributors)
 - [📖 Citation](#citation)
 - [📄 License](#license)
 
@@ -142,6 +143,21 @@ Skills, permissions, Goals, and Automations. See the
 </p>
 
 ## News
+
+**2026-08-07 · Thinking controls, more providers, and a Desktop you can tune**
+
+- **Reasoning controls work again across the board.** Thinking levels are now
+  resolved from the model catalog, so Claude, GPT-5, Kimi, Qwen and Grok all
+  offer their real effort levels, and DeepSeek, GLM and MiniMax get a working
+  thinking toggle. A newly released model inherits its family's controls
+  instead of silently losing them.
+- **Three more providers.** Requesty and Forge join as gateways, and MiniMax
+  arrives with its own catalog entry — including the 1M-context M3 tier.
+- **Make the Desktop yours.** Settings → Appearance adds conversation width,
+  a light/dark override that no longer follows the OS blindly, font size, and
+  font selection filtered to what is actually installed on your machine.
+- **Safer command execution on Windows.** A Job Object backend gives the
+  sandbox real process-tree isolation where previously there was none.
 
 **2026-08-04 · Skills that work wherever you do**
 
@@ -943,6 +959,27 @@ The empty product-image slots have a shared
 </p>
 
 </div>
+
+---
+
+<a id="contributors"></a>
+
+## 🙏 Appreciation
+
+Thanks to everyone in the open-source community — your stars, issues, pull
+requests and discussions shape where DeepCode goes next.
+
+<div align="center">
+
+<a href="https://github.com/HKUDS/DeepCode/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=HKUDS/DeepCode&max=999" alt="DeepCode contributors" />
+</a>
+
+</div>
+
+Everyone who has opened a pull request is listed in
+[CONTRIBUTORS.md](CONTRIBUTORS.md), including contributions that predate the
+v2.0 rebuild and so are not reflected in the graph above.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -134,6 +134,7 @@ Automations。从源码启动请参考
 - [🎬 实时演示](#live-demonstrations)
 - [🛠️ 开发](#开发)
 - [⭐ 星标历史](#star-history)
+- [🙏 致谢](#contributors)
 - [📖 引用](#citation)
 - [📄 许可证](#license)
 
@@ -142,6 +143,18 @@ Automations。从源码启动请参考
 </p>
 
 ## 新闻
+
+**2026-08-07 · 思考强度控制、更多模型服务商、可调的 Desktop**
+
+- **思考强度控制全面恢复。** 思考档位改为从模型目录解析，Claude、GPT-5、
+  Kimi、Qwen、Grok 都能选到各自真实的档位，DeepSeek、GLM、MiniMax 也拿到了
+  可用的思考开关。新发布的模型会继承同族的能力，而不会悄悄失去控制项。
+- **新增三家模型服务商。** Requesty 与 Forge 作为网关加入，MiniMax 拥有独立的
+  目录条目——包含 100 万上下文的 M3 层级。
+- **把 Desktop 调成你习惯的样子。** 设置 → 外观新增会话区宽度、不再盲从系统的
+  浅色/深色手动切换、字号，以及只列出本机实际已安装字体的字体选择。
+- **Windows 上的命令执行更安全。** 新的 Job Object 后端为沙箱带来了真正的
+  进程树隔离——此前这里是空白。
 
 **2026-08-04 · 让 Skills 在每一种工作方式中保持一致**
 
@@ -830,6 +843,27 @@ Desktop 打包、Rust 检查、签名和发布流程请参考
 </p>
 
 </div>
+
+---
+
+<a id="contributors"></a>
+
+## 🙏 致谢
+
+感谢开源社区的每一位——你们的 star、issue、pull request 和讨论，
+共同塑造了 DeepCode 的走向。
+
+<div align="center">
+
+<a href="https://github.com/HKUDS/DeepCode/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=HKUDS/DeepCode&max=999" alt="DeepCode contributors" />
+</a>
+
+</div>
+
+所有提交过 pull request 的贡献者都记录在
+[CONTRIBUTORS.md](CONTRIBUTORS.md) 中，其中也包含早于 v2.0 重构、
+因而未体现在上方贡献图中的那些贡献。
 
 ---
 


### PR DESCRIPTION
## News — 2026-08-07

A user-facing summary of what shipped today, in the style of the existing entries rather than a changelog:

- Reasoning controls resolving correctly again across model families
- Requesty, Forge and MiniMax added as providers
- Desktop appearance settings (conversation width, theme override, font size and selection)
- Windows Job Object sandbox backend

## Appreciation

Follows the shape used in [HKUDS/DeepTutor](https://github.com/HKUDS/DeepTutor) — a `contrib.rocks` avatar mosaic linking to the contributors graph — placed between Star History and Citation, with a matching table-of-contents entry.

It also points at [CONTRIBUTORS.md](CONTRIBUTORS.md), because the graph can only show commits that reached `main`: contributions predating the v2.0 rebuild, and those ported on someone's behalf, do not appear there.

Applied to `README.md` and `README_ZH.md` alike.

## One thing to check after merge

The `contrib.rocks` image for this repo did not resolve when fetched locally, while the equivalent DeepTutor URL returned immediately — the service is up and the URL shape is right, so this looks like a first-generation cache miss rather than a mistake. **Worth confirming the mosaic renders on the merged README**; if it does not, the image URL is the thing to look at.
