### PR TITLE
fix(security): raise the aiohttp floor past the known advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core Dependencies
 aiofiles>=0.8.0
-aiohttp>=3.14.1
+aiohttp>=3.14.3
 anthropic>=0.40.0
 asyncio-mqtt
 


### PR DESCRIPTION
## Why

`requirements.txt` allowed `aiohttp>=3.14.1`. That floor resolves happily to 3.14.1 or 3.14.2 — both affected by advisories the sidecar was already pinned away from:

| advisory | severity | fixed in |
|---|---|---|
| [GHSA-cq5v-8q36-5273](https://github.com/advisories/GHSA-cq5v-8q36-5273) — out-of-bounds heap read in the C HTTP response parser (malformed chunked responses) | **high** | 3.14.3 |
| [GHSA-mfx4-hv73-q22v](https://github.com/advisories/GHSA-mfx4-hv73-q22v) — request smuggling via WebSocket upgrade | medium | 3.14.2 |
| [GHSA-mq44-7p77-q5h7](https://github.com/advisories/GHSA-mq44-7p77-q5h7) — WebSocket client accepts compressed frames without negotiated permessage-deflate | medium | 3.14.2 |

`desktop/sidecar-requirements.{in,lock}` moved to 3.14.3 in `6923382`, but the top-level floor was left behind — so a fresh `pip install` resolving to the lower bound still landed on a vulnerable build. All three declarations now agree on 3.14.3, which is also the current release on PyPI.

## On the open Dependabot alerts

The three aiohttp alerts on this repo are **stale**, not outstanding work. They were opened at 08-04 08:08 UTC; `6923382` pinned the sidecar to 3.14.3 at 09:04 UTC the same day, and `main` has carried 3.14.3 in both `.in` and `.lock` ever since. Dependabot has not rescanned. They can be dismissed as fixed once this lands.

The fourth alert — `glib 0.18.5` in `desktop/src-tauri/Cargo.lock`, wanting ≥ 0.20.0 — is **not** addressed here. `glib` is a shared transitive dependency of twelve gtk-rs crates (`gtk`, `gdk`, `webkit2gtk`, `cairo-rs`, `pango`, `gio`, …), so moving it means a gtk-rs 0.18 → 0.20 migration and, in turn, Tauri itself. The advisory is an `Iterator` unsoundness rather than an exploitable path, so it seems reasonable to wait for the upstream bump.

## Testing

Verified `3.14.3` exists on PyPI (it is the latest release) before setting the floor to it. `pre-commit` clean, including `requirements-txt-fixer`.

CI has not run: GitHub Actions is in a `major_outage` at time of writing, so every workflow on the repo is failing at `Set up job` with `Failed to resolve action download info. Error: Service Unavailable`. **This needs a green run before merge** — it is a one-line dependency change, but that is exactly the kind that should be seen installing cleanly.
