### PR TITLE
fix(security): bump js-yaml past CVE-2026-59870

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -3042,9 +3042,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Why

`npm audit` began failing on `main` without anything in the repo changing — the advisory was published after the last green run (`490aad6`, 08-06 15:22):

```
js-yaml  4.0.0 - 4.3.0
Severity: high
GHSA-5p4m-2wfm-xmqj — quadratic CPU consumption in !!omap resolution
```

It reaches us twice through `json-schema-to-typescript`, which generates the Desktop's protocol types:

```
@deepcode/desktop
└─┬ json-schema-to-typescript@15.0.4
  ├─┬ @apidevtools/json-schema-ref-parser@11.9.3
  │ └── js-yaml@4.3.0
  └── js-yaml@4.3.0
```

That makes it a devDependency rather than something that ships, and a hostile schema is not a threat model this repo has. But the audit gate is set to `--audit-level=high`, and the fix is a patch release, so there is no reason to carry it.

## Change

`4.3.0 → 4.3.1`, **lockfile only** — `package.json` is untouched and no direct dependency moved.

## Testing

From a clean `npm ci`:

| check | result |
|---|---|
| `npm audit --audit-level=high` | **0 vulnerabilities** |
| `npm run check:protocol` | pass — this is the consumer of `js-yaml`, so it is the one that would break |
| `npm run typecheck` | clean |
| `eslint .` | clean |
| `vitest run` | 148 passed, 24 files |
| `npm run build` | ✓ built |

## Note on the two PRs behind this

#165 and #166 are both green on Desktop CI, Linting and Python CI, and red only on Security CI for this same finding. Neither touches npm — one is markdown, the other a Python floor. Merging this first should clear them.
