### PR TITLE
fix(security): bump sidecar pip 26.1.2 → 26.2 (PYSEC-2026-3721)

### DIFF
--- a/desktop/sidecar-requirements.lock
+++ b/desktop/sidecar-requirements.lock
@@ -105,7 +105,7 @@ packaging==26.2
     #   pyinstaller-hooks-contrib
 pefile==2024.8.26 ; sys_platform == 'win32'
     # via pyinstaller
-pip==26.1.2
+pip==26.2
     # via -r sidecar-requirements.in
 prompt-toolkit==3.0.52
     # via -r sidecar-requirements.in


### PR DESCRIPTION
## Problem

Security CI's **`Audit locked App Server environment`** step now fails on every branch (and will also fail on `main`'s next scheduled run), regardless of PR content:

```
Found 1 known vulnerability in 1 package
Name  Version  ID              Fix Versions
----  -------  --------------  ------------
pip   26.1.2   PYSEC-2026-3721  26.2
```

`desktop/sidecar-requirements.lock` pins `pip==26.1.2`, and a new PyPI advisory (**PYSEC-2026-3721**, published after the last green Security CI run on 2026-08-19) flags everything below pip 26.2. The audit builds the sidecar venv from this lock (`npm run setup:sidecar`), so the pinned vulnerable pip is exactly what `pip-audit` scans.

## Fix

One-line bump of the universal lock entry: `pip==26.1.2` → `pip==26.2` (the advisory's listed fix version). pip is a direct entry in `sidecar-requirements.in` and carries no transitive pins in this lock, so the manual bump is equivalent to re-compiling.

## Verification

Reproduced locally against the lock with the same `pip-audit==2.10.1` the workflow installs:

- before: `Found 1 known vulnerability in 1 package` (pip 26.1.2 / PYSEC-2026-3721), exit 1
- after the bump: audit clean, exit 0

This should immediately un-red the Security CI on all open PR branches once merged (branches will need the fix via merge/rebase).