### PR TITLE
fix(tools): close case/whitespace blocklist bypass and native path escape in command executors

### DIFF
--- a/tests/test_command_executor_native_fence.py
+++ b/tests/test_command_executor_native_fence.py
@@ -1,0 +1,86 @@
+"""Issue #128: the native fast path in ``tools/command_executor`` runs
+in-process, before the sandbox wrapper, so ``rm``/``cp``/``mv`` on operands
+outside the working directory executed as plain Python file operations with
+no sandbox at all. The fix declines the fast path (``None``) for those, so
+the command takes the sandboxed shell route every other command uses.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.command_executor import (
+    _try_native_execute,
+    execute_command_batch,
+    execute_single_command,
+)
+
+_seatbelt = platform.system() == "Darwin" and os.path.exists("/usr/bin/sandbox-exec")
+
+
+@pytest.fixture()
+def workspace(tmp_path):
+    ws = tmp_path / "file_tree"
+    ws.mkdir()
+    return ws
+
+
+def test_native_ops_outside_workspace_declined_inside_still_fast(workspace, tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "keep.txt").write_text("precious")
+    (workspace / "a.txt").write_text("x")
+
+    # absolute and ..-escape operands must decline the fast path ...
+    assert _try_native_execute(f"rm -rf {outside}", workspace) is None
+    assert (outside / "keep.txt").exists()
+    assert _try_native_execute("rm -rf ../sibling", workspace) is None
+    assert _try_native_execute("cp a.txt ../elsewhere/b.txt", workspace) is None
+    assert _try_native_execute("mkdir -p ../newly", workspace) is None
+    assert _try_native_execute("touch ../escaped.txt", workspace) is None
+    assert not (workspace.parent / "escaped.txt").exists()
+    assert not (workspace.parent / "newly").exists()
+
+    # ... while in-workspace operands keep it (over-broad gate would break
+    # both assertions' contract: declined vs handled)
+    rc, _, err = _try_native_execute("mkdir -p src/nested", workspace)
+    assert rc == 0, err
+    rc, _, err = _try_native_execute("cp a.txt src/nested/b.txt", workspace)
+    assert rc == 0, err
+    rc, _, err = _try_native_execute("rm -rf src", workspace)
+    assert rc == 0, err
+    assert not (workspace / "src").exists()
+
+
+@pytest.mark.skipif(not _seatbelt, reason="seatbelt sandbox not available")
+@pytest.mark.asyncio
+async def test_public_executors_outside_workspace_rm_sandboxed(workspace):
+    """Through both public tools, a recursive remove targeting the user's
+    home (which the sandbox write-fence denies) must survive. Pre-fix the
+    native handler deleted it in-process with no sandbox involved."""
+    victims = []
+    for name in (".deepcode_fence_v1", ".deepcode_fence_v2"):
+        victim = Path.home() / name
+        victim.mkdir(exist_ok=True)
+        (victim / "keep.txt").write_text("precious")
+        victims.append(victim)
+    try:
+        await execute_single_command(f"rm -rf {victims[0]}", str(workspace))
+        await execute_command_batch(f"rm -rf {victims[1]}", str(workspace))
+        for victim in victims:
+            assert (victim / "keep.txt").exists()
+    finally:
+        for victim in victims:
+            if victim.exists():
+                for child in victim.iterdir():
+                    child.unlink()
+                victim.rmdir()

--- a/tests/test_exec_sandbox_wiring.py
+++ b/tests/test_exec_sandbox_wiring.py
@@ -159,3 +159,28 @@ async def test_execute_python_write_inside_ok(impl_server, tmp_path):
     data = json.loads(out)
     assert data["status"] == "success", data
     assert (tmp_path / "out.txt").read_text() == "ok"
+
+
+# ---- dangerous-command blocklist gating (runs before any execution) --------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command",
+    [
+        "RM  -rf ./marker",
+        "rm\t-rf ./marker",
+        "chmod  777 ./marker",
+    ],
+)
+async def test_execute_bash_blocklist_survives_case_and_spacing(
+    impl_server, tmp_path, command
+):
+    """Issue #128: case and whitespace-run variants must not slip past the
+    substring blocklist. The check returns before any subprocess runs, so
+    this needs no sandbox backend."""
+    impl_server.initialize_workspace(str(tmp_path))
+    out = await impl_server.execute_bash(command, timeout=30)
+    data = json.loads(out)
+    assert data["status"] == "error", data
+    assert "prohibited" in data["message"]

--- a/tools/code_implementation_server.py
+++ b/tools/code_implementation_server.py
@@ -785,7 +785,11 @@ async def execute_bash(command: str, timeout: int = 30) -> str:
     try:
         # 安全检查：禁止危险命令
         dangerous_commands = ["rm -rf", "sudo", "chmod 777", "mkfs", "dd if="]
-        if any(dangerous in command.lower() for dangerous in dangerous_commands):
+        # Normalize case and whitespace runs before matching: "RM  -rf" or
+        # "rm\t-rf" must not slip past a plain substring check. Shallow
+        # defense-in-depth only — the sandbox below is the real boundary.
+        normalized_command = re.sub(r"\s+", " ", command).lower()
+        if any(dangerous in normalized_command for dangerous in dangerous_commands):
             result = {
                 "status": "error",
                 "message": f"Dangerous command execution prohibited: {command}",

--- a/tools/command_executor.py
+++ b/tools/command_executor.py
@@ -52,6 +52,14 @@ def _try_native_execute(command: str, cwd: Path) -> Optional[Tuple[int, str, str
         pp = Path(p)
         return pp if pp.is_absolute() else (cwd / pp)
 
+    # Native handlers run in-process, before the sandbox wrapper, so any
+    # operand resolving outside the working directory declines the fast
+    # path and takes the sandboxed shell route instead, where the OS
+    # write-fence applies.
+    root = cwd.resolve()
+    if any(not _resolve(p).resolve().is_relative_to(root) for p in paths):
+        return None
+
     try:
         if cmd == "mkdir":
             for p in paths:


### PR DESCRIPTION
## Why

Follow-up hardening for #128, the half left open after `shell=True` was removed.

Two gaps remained in the command executors:

- `execute_bash` matched its dangerous-command blocklist against `command.lower()` with plain substring checks, so the exact payloads from the report (`RM  -rf /tmp/test`, `rm<TAB>-rf`) slipped past because of case or a whitespace run inside the pattern.
- In `command_executor`, the native fast path (`mkdir` / `touch` / `rm` / `cp` / `mv` in `_try_native_execute`) runs in-process **before** `build_exec_command` wraps anything. `_resolve` accepted absolute paths and `..` segments, so a command like `rm -rf /some/absolute/dir` executed as plain Python file operations outside the working directory, with no sandbox involved at all. Every other command goes through the sandboxed shell route; these five verbs did not.

## What changed

- `execute_bash`: normalize case and collapse whitespace runs before the substring match (`re.sub(r"\s+", " ", command).lower()`), so spacing/case variants of the blocklisted commands are caught. This stays the shallow defense-in-depth layer; the sandbox below remains the real boundary, as before.
- `_try_native_execute`: decline the fast path (return `None`) whenever any path operand resolves outside the working directory. The command then takes the sandboxed shell route every other command already uses, where the OS write-fence applies. In-workspace operands keep the fast path unchanged.

## Verification

On macOS (seatbelt backend), before this change:

- `execute_single_command("rm -rf <dir under $HOME>", ws)` and the same via `execute_commands` deleted the external directory in-process, no sandbox involved.
- `execute_bash("RM  -rf ./marker")` / `rm<TAB>-rf ./marker"` / `chmod  777 ./marker` returned success, not the prohibited error.

After:

- Both public executors now route the outside-workspace remove through the sandbox and the external directory survives (sandbox-denied failure instead of deletion).
- The three blocklist variants return `Dangerous command execution prohibited` before any execution.
- New tests in `tests/test_command_executor_native_fence.py` (public-API fence check, fails on main) and `tests/test_exec_sandbox_wiring.py` (blocklist variants); all fail on the base revision and pass here. Full focused suite: 14 passed.
