### PR TITLE
fix(plugins): warn on plaintext MCP credentials

### DIFF
--- a/core/plugins/mcp.py
+++ b/core/plugins/mcp.py
@@ -29,6 +29,32 @@ _UNSAFE_SERVER_ID = re.compile(r"[^A-Za-z0-9._-]+")
 _HTTP_HEADER_NAME = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
 _STDIO_FIELDS = frozenset(("type", "command", "args", "env", "cwd"))
 _HTTP_FIELDS = frozenset(("type", "url", "headers"))
+_CREDENTIAL_NAME = re.compile(
+    r"(?:^|[^a-z0-9])(?:authorization|cookie|(?:access|refresh|bearer)[-_]?token|"
+    r"api[-_]?key|password|passwd|secret|private[-_]?key)(?:$|[^a-z0-9])",
+    re.IGNORECASE,
+)
+_CREDENTIAL_VALUE = re.compile(
+    r"(?:"
+    r"\bsk-[A-Za-z0-9_-]{16,}|"
+    r"\bgithub_pat_[A-Za-z0-9_]{20,}|"
+    r"\bgh[pousr]_[A-Za-z0-9]{20,}|"
+    r"\bAKIA[0-9A-Z]{16}\b|"
+    r"\bxox[baprs]-[A-Za-z0-9-]{10,}|"
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----|"
+    r"\bbearer\s+[A-Za-z0-9._~+/=-]{16,}|"
+    r"\b(?:api[-_ ]?key|token|secret|password)\s*[:=]\s*\S{8,}"
+    r")",
+    re.IGNORECASE,
+)
+_CREDENTIAL_PLACEHOLDER = re.compile(
+    r"(?:(?:bearer|basic)\s+)?(?:"
+    r"\$\{[A-Z_][A-Z0-9_]*\}|"
+    r"<[^>\r\n]{1,80}>|"
+    r"(?:your|example|dummy|test|fake|replace[-_ ]?me)(?:[-_ :].*)?"
+    r")",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,7 +129,9 @@ def load_agent_plugin_mcp(root: Path, *, plugin_schema: str) -> AgentPluginMcpRe
     diagnostics: list[PluginDiagnostic] = []
     for name, value in servers.items():
         try:
-            parsed.append(_parse_server(root, name, value))
+            server = _parse_server(root, name, value)
+            parsed.append(server)
+            diagnostics.extend(_credential_diagnostics(server))
         except (ValidationError, ValueError, TypeError) as exc:
             diagnostics.append(
                 PluginDiagnostic(
@@ -119,6 +147,50 @@ def load_agent_plugin_mcp(root: Path, *, plugin_schema: str) -> AgentPluginMcpRe
         tuple(diagnostics),
         revision=revision,
     )
+
+
+def _credential_diagnostics(
+    server: AgentPluginMcpTemplate,
+) -> tuple[PluginDiagnostic, ...]:
+    """Warn about likely credentials without copying their values into output.
+
+    Agent Plugins permits literal ``env`` and ``headers`` values, so rejecting
+    them would make the parser non-conformant.  They are nevertheless package
+    data, not a secret store.  Keep the package usable while making that trust
+    boundary visible before its MCP server starts.
+    """
+
+    findings: list[PluginDiagnostic] = []
+    fields = (
+        ("env", server.definition.env),
+        ("headers", server.definition.headers),
+    )
+    for scope, values in fields:
+        for name, value in values.items():
+            if not _looks_like_credential(name, value):
+                continue
+            findings.append(
+                PluginDiagnostic(
+                    code="agent_plugins.possible_plaintext_credential",
+                    severity=PluginDiagnosticSeverity.WARNING,
+                    message=(
+                        f"Agent Plugin MCP server {server.name!r} field "
+                        f"{scope}.{name} may contain a plaintext credential. "
+                        "Values in mcp.json are distributable package data; "
+                        "bind secrets at runtime in user configuration instead."
+                    ),
+                    component=PluginComponentKind.MCP,
+                    resource="mcp.json",
+                )
+            )
+    return tuple(findings)
+
+
+def _looks_like_credential(name: str, value: str) -> bool:
+    clean = value.strip()
+    if not clean or _CREDENTIAL_PLACEHOLDER.fullmatch(clean):
+        return False
+    return bool(_CREDENTIAL_NAME.search(name) or _CREDENTIAL_VALUE.search(clean))
 
 
 def _parse_server(root: Path, name: Any, value: Any) -> AgentPluginMcpTemplate:

--- a/docs/LOCAL_PLUGINS.md
+++ b/docs/LOCAL_PLUGINS.md
@@ -57,6 +57,12 @@ Streamable HTTP servers to the same session-scoped MCP runtime used by
 standalone configuration. Invalid server entries are skipped independently;
 an invalid MCP component does not disable valid Plugin Skills.
 
+> [!WARNING]
+> Never place credentials in `mcp.json`. Literal `env` and `headers` values are
+> plaintext package data: they can be committed, copied, or disclosed with the
+> Plugin. Bind secrets at runtime from user configuration with `credentialEnv`,
+> `bearerTokenCredential`, or another supported environment reference instead.
+
 Discovery remains inert: listing or registering a Plugin never imports Python
 code or starts a process. When an Agent Session first uses the package,
 DeepCode supplies immutable `PLUGIN_ROOT` and installation-specific

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -14,6 +14,7 @@ from core.mcp.tools import McpToolAdapter
 from core.plugins.domain import (
     PluginComponentKind,
     PluginComponentStatus,
+    PluginDiagnosticSeverity,
     PluginValidationError,
 )
 from core.plugins.formats.agent_plugins_v1 import AGENT_PLUGIN_SCHEMA
@@ -249,6 +250,88 @@ def test_mcp_component_accepts_unrestricted_json_server_names(
     assert plugin_server_id("review-tools", "runtime") == "review-tools--runtime"
     assert plugin_policy_key("review-tools", "数据库/α") == (
         "review-tools/%E6%95%B0%E6%8D%AE%E5%BA%93%2F%CE%B1"
+    )
+
+
+def test_mcp_component_warns_about_plaintext_credentials_without_leaking_values(
+    tmp_path: Path,
+) -> None:
+    root = _write_plugin(tmp_path / "plugin")
+    api_key = "sk-" + "a" * 24
+    bearer = "Bearer " + "b" * 24
+    _write_mcp(
+        root,
+        {
+            "stdio": {
+                "type": "stdio",
+                "command": "python3",
+                "env": {
+                    "OPENAI_API_KEY": api_key,
+                    "RUNTIME_CONFIG": api_key,
+                },
+            },
+            "remote": {
+                "type": "streamable-http",
+                "url": "https://example.com/mcp",
+                "headers": {"Authorization": bearer},
+            },
+        },
+    )
+
+    plugin = resolve_plugin(root)
+    component = plugin.package.component(PluginComponentKind.MCP)
+
+    assert component is not None
+    assert component.status is PluginComponentStatus.READY
+    assert component.item_count == 2
+    warnings = [
+        item
+        for item in component.diagnostics
+        if item.code == "agent_plugins.possible_plaintext_credential"
+    ]
+    assert len(warnings) == 3
+    assert all(item.severity is PluginDiagnosticSeverity.WARNING for item in warnings)
+    messages = "\n".join(item.message for item in warnings)
+    assert "env.OPENAI_API_KEY" in messages
+    assert "env.RUNTIME_CONFIG" in messages
+    assert "headers.Authorization" in messages
+    assert api_key not in messages
+    assert bearer not in messages
+
+
+def test_mcp_component_credential_warning_allows_placeholders_and_benign_names(
+    tmp_path: Path,
+) -> None:
+    root = _write_plugin(tmp_path / "plugin")
+    _write_mcp(
+        root,
+        {
+            "stdio": {
+                "type": "stdio",
+                "command": "python3",
+                "env": {
+                    "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+                    "PASSWORD": "<runtime-injected>",
+                    "TOKENIZERS_PARALLELISM": "false",
+                },
+            },
+            "remote": {
+                "type": "streamable-http",
+                "url": "https://example.com/mcp",
+                "headers": {"Authorization": "Bearer ${SERVICE_TOKEN}"},
+            },
+        },
+    )
+
+    plugin = resolve_plugin(root)
+    component = plugin.package.component(PluginComponentKind.MCP)
+
+    assert component is not None
+    assert component.status is PluginComponentStatus.READY
+    assert component.item_count == 2
+    assert not any(
+        item.code == "agent_plugins.possible_plaintext_credential"
+        for item in component.diagnostics
     )
 
 


### PR DESCRIPTION
## Description

Closes #171.

Agent Plugin `mcp.json` ingestion has shipped since the issue was triaged, but literal `env` and `headers` values were still accepted without a credential-specific diagnostic. This change establishes the requested package-data boundary without rejecting otherwise valid Agent Plugins packages.

## Changes Made

- add parser-aware warnings for credential-like names and common secret value formats in Plugin MCP `env` and `headers`
- keep packages usable by emitting warnings rather than treating spec-valid fields as fatal
- fully redact credential values from diagnostics
- allow obvious placeholders and benign names to avoid noisy false positives
- document that `mcp.json` values are distributable plaintext and point users to runtime credential bindings

## Verification

- `python -m pytest -q tests/test_plugins.py` — 24 passed
- `ruff check core/plugins/mcp.py tests/test_plugins.py`
- `python -m compileall -q core/plugins tests/test_plugins.py`

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated
- [x] Unit tests added