### PR TITLE
feat(runtime): add Session context-window caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ and CLI without export or conversion.
 | Attach a file | Use the composer attachment | `@path/to/file` |
 | Change the next Turn's model | Composer model picker | `/model` |
 | Adjust Thinking effort | Composer effort picker | `/effort` |
+| Cap the Session context window | Model picker context control | `/context` |
 | Choose tool access | Composer access picker | `/permissions` |
 | Load Skills for the next Turn | Composer Skills control | `/skill <name>` |
 | Create a reusable Skill | **Skills → Create Skill** | `$skill-creator` |
@@ -918,6 +919,9 @@ permanent deletion removes the Session records but never repository files.
 Desktop provides connection setup and verification under **Settings → AI
 providers**. In the CLI, `/model` changes the connection and model for future
 Turns, while `/effort` selects a Thinking level supported by that model.
+Use the model picker's context control, or `/context 64k` in the TUI, to make
+future Turns compact history sooner; `/context auto` restores the model's
+published window.
 
 Model changes never rewrite earlier history or alter an active Turn. Thinking
 effort controls the request sent to the provider; transcript detail controls

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -735,6 +735,7 @@ Project，或者从项目目录启动 `deepcode`，然后创建新 Session 或�
 | 附加文件 | 使用输入框附件 | `@文件路径` |
 | 修改下一个 Turn 的模型 | 输入框模型选择器 | `/model` |
 | 调整 Thinking 档位 | 输入框 Thinking 选择器 | `/effort` |
+| 限制 Session 上下文窗口 | 模型选择器上下文控件 | `/context` |
 | 选择工具权限 | 输入框权限选择器 | `/permissions` |
 | 为下一个 Turn 加载 Skills | 输入框 Skills 控件 | `/skill <名称>` |
 | 创建可复用 Skill | **Skills → Create Skill** | `$skill-creator` |
@@ -749,6 +750,8 @@ Session，不删除历史；永久删除只移除 Session 记录，不会删除�
 Desktop 在 **Settings → AI providers** 中提供连接配置与验证。CLI 使用
 `/model` 修改后续 Turn 的连接和模型，使用 `/effort` 选择该模型支持的
 Thinking 档位。
+在模型选择器中设置上下文上限，或在 TUI 中输入 `/context 64k`，可以让
+后续 Turn 更早压缩历史；`/context auto` 会恢复模型公布的上下文窗口。
 
 模型切换不会改写已有历史，也不会改变正在运行的 Turn。Thinking 档位决定
 发送给 Provider 的请求；transcript 详细程度只影响界面展示。DeepCode 只在

--- a/app_server/dispatcher.py
+++ b/app_server/dispatcher.py
@@ -59,7 +59,11 @@ from core.domain.automation import (
     AutomationActivationStatus,
     AutomationScheduleKind,
 )
-from core.domain.execution_profile import ExecutionSelection
+from core.domain.execution_profile import (
+    MAX_CONTEXT_WINDOW_TOKENS,
+    MIN_CONTEXT_WINDOW_TOKENS,
+    ExecutionSelection,
+)
 from core.domain.execution_security import ExecutionAccessPreset
 from core.domain.message_provenance import ClientSurface
 from core.domain.project import TrustState
@@ -168,6 +172,28 @@ class Params:
             return None
         if not isinstance(value, str) or not value.strip():
             raise InvalidParams(f"{name} must be a non-empty string or null")
+        return value
+
+    def nullable_integer(
+        self,
+        name: str,
+        *,
+        minimum: int = 0,
+        maximum: int | None = None,
+    ) -> int | None:
+        if name not in self.values:
+            raise InvalidParams(f"{name} is required")
+        value = self.values[name]
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise InvalidParams(f"{name} must be an integer or null")
+        if value < minimum or (maximum is not None and value > maximum):
+            if maximum is None:
+                raise InvalidParams(f"{name} must be at least {minimum} or null")
+            raise InvalidParams(
+                f"{name} must be between {minimum} and {maximum}, or null"
+            )
         return value
 
 
@@ -862,6 +888,7 @@ class Dispatcher:
             "connectionId",
             "model",
             "reasoningEffort",
+            "contextWindow",
             "workspacePath",
             "parentThreadId",
             "agentPreset",
@@ -878,6 +905,11 @@ class Dispatcher:
             connection_id=params.string("connectionId", required=False),
             model=params.string("model", required=False),
             reasoning_effort=params.string("reasoningEffort", required=False),
+            context_window=params.optional_integer(
+                "contextWindow",
+                minimum=MIN_CONTEXT_WINDOW_TOKENS,
+                maximum=MAX_CONTEXT_WINDOW_TOKENS,
+            ),
             workspace_path=params.string("workspacePath", required=False),
             parent_thread_id=params.string("parentThreadId", required=False),
             agent_preset=params.string("agentPreset", required=False),
@@ -928,6 +960,7 @@ class Dispatcher:
                     connection_id=connection_id,
                     model_id=model,
                     reasoning_effort=current.reasoning_effort,
+                    context_window=current.context_window,
                 ),
             )
             thread = self.application.threads.set_execution_selection(
@@ -944,6 +977,7 @@ class Dispatcher:
                     connection_id=current.connection_id,
                     model_id=model,
                     reasoning_effort=current.reasoning_effort,
+                    context_window=current.context_window,
                 ),
             )
             thread = self.application.threads.set_model(
@@ -955,18 +989,34 @@ class Dispatcher:
     def _thread_execution_update(self, params: Params) -> dict[str, Any]:
         """Atomically validate and update the future-Turn execution choice."""
 
-        params.only("threadId", "connectionId", "model", "reasoningEffort")
+        params.only(
+            "threadId",
+            "connectionId",
+            "model",
+            "reasoningEffort",
+            "contextWindow",
+        )
         thread_id = str(params.string("threadId"))
         current = self.application.threads.read(thread_id)
         connection_id = params.nullable_string("connectionId")
         model = params.nullable_string("model")
         reasoning_effort = params.nullable_string("reasoningEffort")
+        context_window = (
+            params.nullable_integer(
+                "contextWindow",
+                minimum=MIN_CONTEXT_WINDOW_TOKENS,
+                maximum=MAX_CONTEXT_WINDOW_TOKENS,
+            )
+            if "contextWindow" in params.values
+            else current.context_window
+        )
         self.application.llm.resolve(
             current.workspace_path,
             ExecutionSelection(
                 connection_id=connection_id,
                 model_id=model,
                 reasoning_effort=reasoning_effort,
+                context_window=context_window,
             ),
         )
         thread = self.application.threads.set_execution_selection(
@@ -974,6 +1024,7 @@ class Dispatcher:
             connection_id=connection_id,
             model=model,
             reasoning_effort=reasoning_effort,
+            context_window=context_window,
         )
         return {"thread": thread_view(thread)}
 

--- a/cli/execution_options.py
+++ b/cli/execution_options.py
@@ -3,8 +3,15 @@
 from __future__ import annotations
 
 import argparse
+import re
 
+from core.domain.execution_profile import (
+    MAX_CONTEXT_WINDOW_TOKENS,
+    MIN_CONTEXT_WINDOW_TOKENS,
+)
 from core.domain.execution_security import ExecutionAccessPreset
+
+_CONTEXT_WINDOW = re.compile(r"^(\d+(?:\.\d+)?)\s*([km]?)$", re.IGNORECASE)
 
 
 def add_reasoning_effort_argument(parser: argparse.ArgumentParser) -> None:
@@ -25,6 +32,29 @@ def add_reasoning_effort_argument(parser: argparse.ArgumentParser) -> None:
             "level supported by the selected model."
         ),
     )
+
+
+def parse_context_window(value: str) -> int | None:
+    """Parse a human context cap (``32k``, ``1m``), or ``auto`` to inherit."""
+
+    clean = value.strip().lower()
+    if clean in {"auto", "default", "inherit"}:
+        return None
+    match = _CONTEXT_WINDOW.fullmatch(clean)
+    if match is None:
+        raise ValueError("context window must be auto or a token count such as 32k")
+    amount = float(match.group(1))
+    multiplier = {"": 1, "k": 1_000, "m": 1_000_000}[match.group(2).lower()]
+    tokens = amount * multiplier
+    if not tokens.is_integer():
+        raise ValueError("context window must resolve to a whole token count")
+    parsed = int(tokens)
+    if not MIN_CONTEXT_WINDOW_TOKENS <= parsed <= MAX_CONTEXT_WINDOW_TOKENS:
+        raise ValueError(
+            "context window must be between "
+            f"{MIN_CONTEXT_WINDOW_TOKENS} and {MAX_CONTEXT_WINDOW_TOKENS} tokens"
+        )
+    return parsed
 
 
 def add_access_preset_argument(parser: argparse.ArgumentParser) -> None:
@@ -61,4 +91,5 @@ __all__ = [
     "add_reasoning_effort_argument",
     "add_workspace_trust_argument",
     "parse_access_preset",
+    "parse_context_window",
 ]

--- a/cli/tui/app.py
+++ b/cli/tui/app.py
@@ -102,6 +102,7 @@ class TuiApp:
             if reasoning_effort is not None
             else None
         )
+        self._requested_context_window: int | None = None
         self.selected_skill_ids: list[str] = []
         self._session_activity: FileLease | None = None
         self._leased_session_id: str | None = None
@@ -132,6 +133,7 @@ class TuiApp:
         self._requested_connection = profile.connection_id
         self._requested_model = profile.model_id
         self._requested_reasoning_effort = thread.reasoning_effort
+        self._requested_context_window = thread.context_window
         self.bridge = SessionBridge(
             store=self.thread_client.store,
             session_id=thread.id,
@@ -236,6 +238,7 @@ class TuiApp:
             connection_id=connection_id,
             model=model,
             reasoning_effort=effort,
+            context_window=self._requested_context_window,
         )
         self.model = profile.model_id
         self._requested_connection = profile.connection_id
@@ -271,9 +274,22 @@ class TuiApp:
             connection_id=self.thread_client.execution_profile.connection_id,
             model=self.thread_client.execution_profile.model_id,
             reasoning_effort=requested,
+            context_window=self._requested_context_window,
         )
         self.model = profile.model_id
         self._requested_reasoning_effort = requested
+
+    async def switch_context_window(self, context_window: int | None) -> None:
+        """Change the context cap for future Turns in this Session."""
+
+        profile = self.thread_client.switch_execution(
+            connection_id=self.thread_client.execution_profile.connection_id,
+            model=self.thread_client.execution_profile.model_id,
+            reasoning_effort=self._requested_reasoning_effort,
+            context_window=context_window,
+        )
+        self.model = profile.model_id
+        self._requested_context_window = context_window
 
     def connection_views(self) -> list[dict]:
         data = self.thread_client.application.llm.list_connections(
@@ -290,7 +306,8 @@ class TuiApp:
         profile = self.thread_client.execution_profile
         current = (
             f"connection: {profile.connection_id} · model: {self.model} · "
-            f"effort: {self.requested_reasoning_effort}"
+            f"effort: {self.requested_reasoning_effort} · "
+            f"context: {self.requested_context_window}"
         )
         views = [
             view
@@ -414,6 +431,11 @@ class TuiApp:
         """User-facing selection; ``auto`` means provider/model default."""
 
         return self._requested_reasoning_effort or "auto"
+
+    @property
+    def requested_context_window(self) -> str:
+        value = self._requested_context_window
+        return f"{value} tokens" if value is not None else "auto"
 
     def clear_conversation(self) -> None:
         self.goal_controller.close()

--- a/cli/tui/commands.py
+++ b/cli/tui/commands.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from cli.transcript import TranscriptMode
+from cli.execution_options import parse_context_window
 from cli.tui import theme
 from cli.tui.picker import Picker, PickerItem, PickerScope, PickerVariant
 from cli.tui.text import fit_head, short_path
@@ -130,6 +131,14 @@ def _permission_presets(app, prefix: str) -> list[str]:
 def _effort_levels(app, prefix: str) -> list[str]:
     levels = ("auto", "none", *app.reasoning_options(app.model))
     return [level for level in levels if level.startswith(prefix)]
+
+
+def _context_windows(app, prefix: str) -> list[str]:
+    return [
+        value
+        for value in ("auto", "32k", "64k", "128k", "256k", "512k", "1m")
+        if value.startswith(prefix.lower())
+    ]
 
 
 def _resolve_session_prefix(app, target: str) -> str | list[str]:
@@ -441,6 +450,26 @@ async def _cmd_effort(app, args: str) -> str | None:
     return (
         f"effort switched to {app.requested_reasoning_effort} "
         f"(effective: {effective}; history preserved)"
+    )
+
+
+async def _cmd_context(app, args: str) -> str | None:
+    wanted = args.strip()
+    profile = app.thread_client.execution_profile
+    if not wanted:
+        return (
+            f"context cap: {app.requested_context_window} · "
+            f"effective: {profile.context_window} tokens"
+        )
+    try:
+        requested = parse_context_window(wanted)
+        await app.switch_context_window(requested)
+    except (OSError, RuntimeError, ValueError) as exc:
+        return f"context switch failed: {exc}"
+    profile = app.thread_client.execution_profile
+    return (
+        f"context cap switched to {app.requested_context_window} "
+        f"(effective: {profile.context_window} tokens; history preserved)"
     )
 
 
@@ -764,6 +793,13 @@ REGISTRY: dict[str, Command] = {
             "show or switch reasoning effort",
             _cmd_effort,
             arguments=_effort_levels,
+        ),
+        Command(
+            "context",
+            "/context [auto|tokens]",
+            "show or set this Session's context-window cap",
+            _cmd_context,
+            arguments=_context_windows,
         ),
         Command(
             "permissions",

--- a/cli/tui/thread_client.py
+++ b/cli/tui/thread_client.py
@@ -325,6 +325,7 @@ class TuiThreadClient:
             connection_id=self.execution_profile.connection_id,
             model=self.execution_profile.model_id,
             reasoning_effort=self._requested.reasoning_effort,
+            context_window=self._requested.context_window,
             workspace_path=self.workspace,
         )
         self._replace_thread(thread)
@@ -391,11 +392,13 @@ class TuiThreadClient:
         connection_id: str | None,
         model: str | None,
         reasoning_effort: str | None,
+        context_window: int | None,
     ) -> ExecutionProfile:
         selection = ExecutionSelection(
             connection_id=connection_id,
             model_id=model,
             reasoning_effort=reasoning_effort,
+            context_window=context_window,
         )
         profile = self.application.llm.resolve(self.workspace, selection)
         self.thread = self.application.threads.set_execution_selection(
@@ -403,6 +406,7 @@ class TuiThreadClient:
             connection_id=profile.connection_id,
             model=profile.model_id,
             reasoning_effort=reasoning_effort,
+            context_window=context_window,
         )
         self._requested = selection
         self.execution_profile = profile
@@ -462,6 +466,7 @@ class TuiThreadClient:
                 connection_id=profile.connection_id,
                 model=profile.model_id,
                 reasoning_effort=self._requested.reasoning_effort,
+                context_window=self._requested.context_window,
                 workspace_path=self.workspace,
             )
         thread = self.application.threads.resume(
@@ -476,6 +481,11 @@ class TuiThreadClient:
                 if self._requested.reasoning_effort is not None
                 else thread.reasoning_effort
             ),
+            context_window=(
+                self._requested.context_window
+                if self._requested.context_window is not None
+                else thread.context_window
+            ),
         )
         self._requested = stored_selection
         profile = self.application.llm.resolve(self.workspace, stored_selection)
@@ -484,6 +494,7 @@ class TuiThreadClient:
             connection_id=profile.connection_id,
             model=profile.model_id,
             reasoning_effort=stored_selection.reasoning_effort,
+            context_window=stored_selection.context_window,
         )
 
     def _resolve_selection(self, thread: Thread) -> ExecutionProfile:
@@ -495,6 +506,7 @@ class TuiThreadClient:
             connection_id=thread.connection_id,
             model_id=thread.model,
             reasoning_effort=thread.reasoning_effort,
+            context_window=thread.context_window,
         )
         self._requested = selection
         return self.application.llm.resolve(self.workspace, selection)

--- a/core/application/thread_service.py
+++ b/core/application/thread_service.py
@@ -22,7 +22,12 @@ from core.application.event_service import EventBroker
 from core.application.views import item_view, thread_view, turn_view, workflow_view
 from core.domain.common import new_id, utc_now
 from core.domain.event import DomainEvent
-from core.domain.execution_profile import ExecutionProfile
+from core.domain.execution_profile import (
+    MAX_CONTEXT_WINDOW_TOKENS,
+    MIN_CONTEXT_WINDOW_TOKENS,
+    ExecutionProfile,
+    ExecutionSelection,
+)
 from core.domain.execution_security import (
     ExecutionAccessPreset,
     ExecutionSecurityProfile,
@@ -140,6 +145,7 @@ class ThreadService:
         model: str | None = None,
         connection_id: str | None = None,
         reasoning_effort: str | None = None,
+        context_window: int | None = None,
         access_preset_override: ExecutionAccessPreset | None = None,
         workspace_path: str | None = None,
         parent_thread_id: str | None = None,
@@ -178,6 +184,7 @@ class ThreadService:
             else None
         )
         resolved_reasoning = normalize_reasoning_effort(reasoning_effort)
+        resolved_context_window = self._normalize_context_window(context_window)
         if access_preset_override is not None and not isinstance(
             access_preset_override,
             ExecutionAccessPreset,
@@ -222,6 +229,7 @@ class ThreadService:
             "model": resolved_model,
             "connection_id": resolved_connection,
             "reasoning_effort": resolved_reasoning,
+            "context_window": resolved_context_window,
             "access_preset_override": (
                 access_preset_override.value
                 if access_preset_override is not None
@@ -468,6 +476,7 @@ class ThreadService:
         connection_id: str | None,
         model: str | None,
         reasoning_effort: str | None | object = _UNSET,
+        context_window: int | None | object = _UNSET,
     ) -> Thread:
         """Atomically change the selection used by future Turns."""
 
@@ -477,13 +486,17 @@ class ThreadService:
             else None
         )
         resolved_model = model.strip() if model and model.strip() else None
-        metadata: dict[str, str | None] = {
+        metadata: dict[str, object] = {
             "connection_id": resolved_connection,
             "model": resolved_model,
         }
         if reasoning_effort is not _UNSET:
             metadata["reasoning_effort"] = normalize_reasoning_effort(
                 reasoning_effort if isinstance(reasoning_effort, str) else None
+            )
+        if context_window is not _UNSET:
+            metadata["context_window"] = self._normalize_context_window(
+                context_window if isinstance(context_window, int) else None
             )
         if not self.session_store.update_metadata(thread_id, metadata):
             raise ThreadNotFoundError(f"thread not found: {thread_id}")
@@ -630,6 +643,7 @@ class ThreadService:
         model = self._model_for(metadata)
         connection_id = self._connection_for(metadata)
         reasoning_effort = self._reasoning_for(metadata)
+        context_window = self._context_window_for(metadata)
         access_preset_override = self._access_preset_for(metadata)
         archived = bool(metadata.get("archived"))
         archived_at = (
@@ -661,6 +675,7 @@ class ThreadService:
                     model=model,
                     connection_id=connection_id,
                     reasoning_effort=reasoning_effort,
+                    context_window=context_window,
                     access_preset_override=access_preset_override,
                     workspace_path=str(workspace),
                     created_at=canonical_created,
@@ -699,6 +714,7 @@ class ThreadService:
                     model=model,
                     connection_id=connection_id,
                     reasoning_effort=reasoning_effort,
+                    context_window=context_window,
                     access_preset_override=access_preset_override,
                     workspace_path=str(workspace),
                     updated_at=updated_at,
@@ -1237,6 +1253,7 @@ class ThreadService:
             "model": thread.model,
             "connection_id": thread.connection_id,
             "reasoning_effort": thread.reasoning_effort,
+            "context_window": thread.context_window,
             "access_preset_override": (
                 thread.access_preset_override.value
                 if thread.access_preset_override is not None
@@ -1274,6 +1291,7 @@ class ThreadService:
             thread.model,
             thread.connection_id,
             thread.reasoning_effort,
+            thread.context_window,
             thread.access_preset_override,
             thread.status is ThreadStatus.ARCHIVED,
             thread.archived_at,
@@ -1509,6 +1527,29 @@ class ThreadService:
     def _reasoning_for(metadata: dict) -> str | None:
         raw = metadata.get("reasoning_effort") or metadata.get("reasoningEffort")
         return normalize_reasoning_effort(str(raw)) if raw is not None else None
+
+    @staticmethod
+    def _context_window_for(metadata: dict) -> int | None:
+        raw = metadata.get("context_window") or metadata.get("contextWindow")
+        if (
+            isinstance(raw, bool)
+            or not isinstance(raw, int)
+            or raw < MIN_CONTEXT_WINDOW_TOKENS
+            or raw > MAX_CONTEXT_WINDOW_TOKENS
+        ):
+            return None
+        return raw
+
+    @staticmethod
+    def _normalize_context_window(value: int | None) -> int | None:
+        if value is not None and (
+            isinstance(value, bool) or not isinstance(value, int)
+        ):
+            raise InvalidArgumentError("context_window must be an integer or None")
+        try:
+            return ExecutionSelection(context_window=value).normalized().context_window
+        except ValueError as exc:
+            raise InvalidArgumentError(str(exc)) from exc
 
     @staticmethod
     def _access_preset_for(metadata: dict) -> ExecutionAccessPreset | None:

--- a/core/application/turn_service.py
+++ b/core/application/turn_service.py
@@ -621,6 +621,7 @@ class TurnService:
                             if reasoning_effort is not None
                             else thread.reasoning_effort
                         ),
+                        context_window=thread.context_window,
                     ),
                 )
             goal_turns = (
@@ -1170,6 +1171,7 @@ class TurnService:
                 connection_id=thread.connection_id,
                 model_id=thread.model,
                 reasoning_effort=thread.reasoning_effort,
+                context_window=thread.context_window,
             ),
         )
         return await self.session_runtimes.compact_live_history(
@@ -1737,6 +1739,7 @@ class TurnService:
                         connection_id=thread.connection_id,
                         model_id=thread.model,
                         reasoning_effort=thread.reasoning_effort,
+                        context_window=thread.context_window,
                     ),
                 )
                 running = replace(running, execution_profile=profile)

--- a/core/application/views.py
+++ b/core/application/views.py
@@ -430,6 +430,7 @@ def thread_view(thread: Thread) -> dict[str, Any]:
         "model": thread.model,
         "connectionId": thread.connection_id,
         "reasoningEffort": thread.reasoning_effort,
+        "contextWindow": thread.context_window,
         "accessPresetOverride": (
             thread.access_preset_override.value
             if thread.access_preset_override is not None

--- a/core/application/workflow_service.py
+++ b/core/application/workflow_service.py
@@ -695,6 +695,7 @@ class WorkflowService:
                 connection_id=thread.connection_id,
                 model_id=thread.model,
                 reasoning_effort=thread.reasoning_effort,
+                context_window=thread.context_window,
             )
             phase_profiles = self.llm_configuration.resolve_phases(
                 context.root,

--- a/core/domain/execution_profile.py
+++ b/core/domain/execution_profile.py
@@ -6,6 +6,9 @@ import math
 from dataclasses import dataclass
 from typing import Any
 
+MIN_CONTEXT_WINDOW_TOKENS = 4_096
+MAX_CONTEXT_WINDOW_TOKENS = 10_000_000
+
 
 @dataclass(frozen=True, slots=True)
 class ExecutionSelection:
@@ -14,12 +17,26 @@ class ExecutionSelection:
     connection_id: str | None = None
     model_id: str | None = None
     reasoning_effort: str | None = None
+    context_window: int | None = None
 
     def normalized(self) -> "ExecutionSelection":
+        context_window = self.context_window
+        if context_window is not None:
+            if isinstance(context_window, bool) or not isinstance(context_window, int):
+                raise ValueError("context_window must be an integer or None")
+            if context_window < MIN_CONTEXT_WINDOW_TOKENS:
+                raise ValueError(
+                    f"context_window must be at least {MIN_CONTEXT_WINDOW_TOKENS}"
+                )
+            if context_window > MAX_CONTEXT_WINDOW_TOKENS:
+                raise ValueError(
+                    f"context_window must be at most {MAX_CONTEXT_WINDOW_TOKENS}"
+                )
         return ExecutionSelection(
             connection_id=_clean_optional(self.connection_id),
             model_id=_clean_optional(self.model_id),
             reasoning_effort=_clean_optional(self.reasoning_effort),
+            context_window=context_window,
         )
 
 
@@ -109,4 +126,9 @@ def _clean_optional(value: str | None) -> str | None:
     return clean or None
 
 
-__all__ = ["ExecutionProfile", "ExecutionSelection"]
+__all__ = [
+    "MIN_CONTEXT_WINDOW_TOKENS",
+    "MAX_CONTEXT_WINDOW_TOKENS",
+    "ExecutionProfile",
+    "ExecutionSelection",
+]

--- a/core/domain/thread.py
+++ b/core/domain/thread.py
@@ -13,6 +13,10 @@ from core.domain.common import (
     require_prefixed_id,
     utc_now,
 )
+from core.domain.execution_profile import (
+    MAX_CONTEXT_WINDOW_TOKENS,
+    MIN_CONTEXT_WINDOW_TOKENS,
+)
 from core.domain.execution_security import ExecutionAccessPreset
 
 
@@ -42,6 +46,7 @@ class Thread:
     model: str | None = None
     connection_id: str | None = None
     reasoning_effort: str | None = None
+    context_window: int | None = None
     access_preset_override: ExecutionAccessPreset | None = None
     parent_thread_id: str | None = None
     worktree_path: str | None = None
@@ -63,6 +68,19 @@ class Thread:
             require_non_empty(self.connection_id, "connection_id")
         if self.reasoning_effort is not None:
             require_non_empty(self.reasoning_effort, "reasoning_effort")
+        if self.context_window is not None:
+            if isinstance(self.context_window, bool) or not isinstance(
+                self.context_window, int
+            ):
+                raise TypeError("context_window must be an integer or None")
+            if self.context_window < MIN_CONTEXT_WINDOW_TOKENS:
+                raise ValueError(
+                    f"context_window must be at least {MIN_CONTEXT_WINDOW_TOKENS}"
+                )
+            if self.context_window > MAX_CONTEXT_WINDOW_TOKENS:
+                raise ValueError(
+                    f"context_window must be at most {MAX_CONTEXT_WINDOW_TOKENS}"
+                )
         if self.access_preset_override is not None and not isinstance(
             self.access_preset_override,
             ExecutionAccessPreset,

--- a/core/persistence/migrations.py
+++ b/core/persistence/migrations.py
@@ -1310,6 +1310,19 @@ ALTER TABLE threads DROP COLUMN web_search_mode_override;
 _REMOVE_WEB_ACCESS_POLICY_V16 = _DROP_WEB_ACCESS_POLICY_V15
 _RESTORE_WEB_ACCESS_POLICY_V16 = _WEB_ACCESS_POLICY_V15
 
+_SESSION_CONTEXT_WINDOW_V17 = r"""
+ALTER TABLE threads
+    ADD COLUMN context_window INTEGER
+    CHECK (
+        context_window IS NULL OR
+        context_window BETWEEN 4096 AND 10000000
+    );
+"""
+
+_DROP_SESSION_CONTEXT_WINDOW_V17 = r"""
+ALTER TABLE threads DROP COLUMN context_window;
+"""
+
 MIGRATIONS = (
     Migration(1, "initial_domain", _INITIAL_SCHEMA, _DROP_INITIAL_SCHEMA),
     Migration(
@@ -1401,6 +1414,12 @@ MIGRATIONS = (
         "remove_web_access_policy",
         _REMOVE_WEB_ACCESS_POLICY_V16,
         _RESTORE_WEB_ACCESS_POLICY_V16,
+    ),
+    Migration(
+        17,
+        "session_context_window",
+        _SESSION_CONTEXT_WINDOW_V17,
+        _DROP_SESSION_CONTEXT_WINDOW_V17,
     ),
 )
 LATEST_SCHEMA_VERSION = MIGRATIONS[-1].version

--- a/core/persistence/thread_repository.py
+++ b/core/persistence/thread_repository.py
@@ -39,6 +39,9 @@ class ThreadRepository:
             dump_datetime(thread.updated_at),
             dump_datetime(thread.archived_at),
         )
+        if self._has_context_window_column():
+            columns += ", context_window"
+            values += (thread.context_window,)
         if self._has_access_preset_column():
             columns += ", access_preset_override"
             values += (
@@ -56,6 +59,9 @@ class ThreadRepository:
         access_assignment = (
             ", access_preset_override = ?" if self._has_access_preset_column() else ""
         )
+        context_assignment = (
+            ", context_window = ?" if self._has_context_window_column() else ""
+        )
         values: tuple[object, ...] = (
             thread.project_id,
             thread.parent_thread_id,
@@ -70,6 +76,8 @@ class ThreadRepository:
             dump_datetime(thread.updated_at),
             dump_datetime(thread.archived_at),
         )
+        if context_assignment:
+            values += (thread.context_window,)
         if access_assignment:
             values += (
                 thread.access_preset_override.value
@@ -81,7 +89,8 @@ class ThreadRepository:
             "UPDATE threads SET project_id = ?, parent_thread_id = ?, title = ?, "
             "mode = ?, status = ?, model = ?, connection_id = ?, "
             "workspace_path = ?, worktree_path = ?, reasoning_effort = ?, "
-            f"updated_at = ?, archived_at = ?{access_assignment} WHERE id = ?",
+            f"updated_at = ?, archived_at = ?{context_assignment}"
+            f"{access_assignment} WHERE id = ?",
             values,
         )
         if cursor.rowcount != 1:
@@ -133,6 +142,7 @@ class ThreadRepository:
     @staticmethod
     def _from_row(row: sqlite3.Row) -> Thread:
         access_preset_available = "access_preset_override" in row.keys()
+        context_window_available = "context_window" in row.keys()
         return Thread(
             id=row["id"],
             project_id=row["project_id"],
@@ -143,6 +153,9 @@ class ThreadRepository:
             model=row["model"],
             connection_id=row["connection_id"],
             reasoning_effort=row["reasoning_effort"],
+            context_window=(
+                row["context_window"] if context_window_available else None
+            ),
             access_preset_override=(
                 ExecutionAccessPreset(row["access_preset_override"])
                 if access_preset_available and row["access_preset_override"] is not None
@@ -158,5 +171,11 @@ class ThreadRepository:
     def _has_access_preset_column(self) -> bool:
         return any(
             row["name"] == "access_preset_override"
+            for row in self.connection.execute("PRAGMA table_info(threads)")
+        )
+
+    def _has_context_window_column(self) -> bool:
+        return any(
+            row["name"] == "context_window"
             for row in self.connection.execute("PRAGMA table_info(threads)")
         )

--- a/core/providers/profiles.py
+++ b/core/providers/profiles.py
@@ -181,12 +181,26 @@ class ConnectionResolver:
         connection, model = self.resolve_selection(normalized, phase=phase)
         settings = self.config.resolve_phase(phase)
         info = resolve_model_info(model)
-        context_window, max_output_tokens = model_limits or (
+        published_context_window, max_output_tokens = model_limits or (
             info.context_window,
             info.max_output_tokens,
         )
-        if context_window < 1 or max_output_tokens < 1:
+        if published_context_window < 1 or max_output_tokens < 1:
             raise ConfigError(f"Invalid model limits for '{model}'")
+        max_tokens = min(settings.max_tokens, max_output_tokens)
+        context_window = published_context_window
+        if normalized.context_window is not None:
+            if normalized.context_window > published_context_window:
+                raise ConfigError(
+                    f"Context window cap {normalized.context_window} exceeds "
+                    f"the published {published_context_window} token window for '{model}'"
+                )
+            if normalized.context_window <= max_tokens:
+                raise ConfigError(
+                    f"Context window cap must exceed the {max_tokens} token "
+                    "generation limit"
+                )
+            context_window = normalized.context_window
         capabilities = reasoning_capabilities or infer_reasoning_capabilities(
             model,
             provider_name=connection.provider_name,
@@ -206,7 +220,7 @@ class ConnectionResolver:
             model_id=model,
             context_window=context_window,
             max_output_tokens=max_output_tokens,
-            max_tokens=min(settings.max_tokens, max_output_tokens),
+            max_tokens=max_tokens,
             temperature=settings.temperature,
             reasoning_effort=reasoning_effort,
             config_revision=self.connection_revision(connection),

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -746,6 +746,10 @@ class TestRuntime implements DesktopRuntime {
           connectionId: request.connectionId,
           model: request.model,
           reasoningEffort: request.reasoningEffort,
+          contextWindow:
+            request.contextWindow === undefined
+              ? this.threadState[index].contextWindow
+              : request.contextWindow,
         };
         return { thread: this.threadState[index] } as MethodResults[M];
       }
@@ -1128,6 +1132,7 @@ const thread: Thread = {
   model: null,
   connectionId: null,
   reasoningEffort: null,
+  contextWindow: null,
   accessPresetOverride: null,
   workspacePath: project.canonicalPath,
   worktreePath: null,
@@ -2933,6 +2938,10 @@ describe("desktop command center", () => {
     const highEffort = screen.getByRole("radio", { name: "High" });
     fireEvent.click(highEffort);
     expect(highEffort.getAttribute("aria-checked")).toBe("true");
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "Context window cap" }),
+      { target: { value: "64000" } },
+    );
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));
     await waitFor(() => {
       expect(runtime.calls).toContain("thread/execution/update");
@@ -2947,6 +2956,7 @@ describe("desktop command center", () => {
       connectionId: "openai",
       model: "gpt-5-mini",
       reasoningEffort: "high",
+      contextWindow: 64_000,
     });
 
     fireEvent.change(permissions, { target: { value: "read_only" } });

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -350,11 +350,17 @@ export function App({ runtime = tauriRuntime }: { runtime?: DesktopRuntime }) {
                 disabledReason={disabledReason}
                 transcriptMode={transcript.mode}
                 onTranscriptModeChange={transcript.selectMode}
-                onModelChange={(connectionId, model, reasoningEffort) =>
+                onModelChange={(
+                  connectionId,
+                  model,
+                  reasoningEffort,
+                  contextWindow,
+                ) =>
                   void controller.setThreadExecution(
                     connectionId,
                     model,
                     reasoningEffort,
+                    contextWindow,
                   )
                 }
                 onAccessPresetChange={controller.setAccessPreset}

--- a/desktop/src/app/useWorkspaceController.ts
+++ b/desktop/src/app/useWorkspaceController.ts
@@ -91,6 +91,7 @@ export interface WorkspaceController {
     connectionId: string | null,
     model: string | null,
     reasoningEffort: string | null,
+    contextWindow: number | null,
   ): Promise<void>;
   setAccessPreset(preset: ExecutionAccessPreset | null): Promise<boolean>;
   refreshSettings(): Promise<void>;
@@ -506,6 +507,7 @@ export function useWorkspaceController(runtime: DesktopRuntime): WorkspaceContro
       connectionId: string | null,
       model: string | null,
       reasoningEffort: string | null,
+      contextWindow: number | null,
     ) =>
       withBusy(async () => {
         if (!selectedThread) return;
@@ -514,6 +516,7 @@ export function useWorkspaceController(runtime: DesktopRuntime): WorkspaceContro
           connectionId,
           model,
           reasoningEffort,
+          contextWindow,
         });
         dispatch({ type: "thread-upsert", thread: result.thread });
       }),

--- a/desktop/src/app/workspaceState.test.ts
+++ b/desktop/src/app/workspaceState.test.ts
@@ -67,6 +67,7 @@ describe("workspace event projection", () => {
     model: null,
     connectionId: null,
     reasoningEffort: null,
+    contextWindow: null,
     accessPresetOverride: null,
     workspacePath: "/workspace/project-1",
     worktreePath: null,

--- a/desktop/src/features/automations/AutomationsPage.test.tsx
+++ b/desktop/src/features/automations/AutomationsPage.test.tsx
@@ -50,6 +50,7 @@ function goalThread(id = "thread-automation"): Thread {
     model: null,
     connectionId: null,
     reasoningEffort: null,
+    contextWindow: null,
     accessPresetOverride: null,
     workspacePath: project.canonicalPath,
     worktreePath: null,

--- a/desktop/src/features/execution/Composer.tsx
+++ b/desktop/src/features/execution/Composer.tsx
@@ -67,6 +67,7 @@ interface ComposerProps {
     connectionId: string | null,
     model: string | null,
     reasoningEffort: string | null,
+    contextWindow: number | null,
   ): void;
   onAccessPresetChange(preset: ExecutionAccessPreset | null): Promise<boolean>;
   onSetGoal(input: GoalDefinitionInput): Promise<void>;

--- a/desktop/src/features/execution/ModelPicker.module.css
+++ b/desktop/src/features/execution/ModelPicker.module.css
@@ -285,6 +285,35 @@
   color: var(--text-primary);
 }
 
+.context {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 150px;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 14px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.context > div {
+  display: grid;
+  gap: 2px;
+}
+
+.context strong {
+  color: var(--text-primary);
+  font-size: var(--text-2xs);
+}
+
+.context span {
+  color: var(--text-tertiary);
+  font-size: var(--text-micro);
+}
+
+.context select {
+  min-height: 34px;
+  font: var(--text-2xs) var(--font-mono);
+}
+
 .menu > footer {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto auto;

--- a/desktop/src/features/execution/ModelPicker.tsx
+++ b/desktop/src/features/execution/ModelPicker.tsx
@@ -29,6 +29,7 @@ interface ModelPickerProps {
     connectionId: string | null,
     model: string | null,
     reasoningEffort: string | null,
+    contextWindow: number | null,
   ): void;
 }
 
@@ -49,6 +50,7 @@ export function ModelPicker({
   const [connectionId, setConnectionId] = useState("");
   const [modelId, setModelId] = useState("");
   const [reasoningEffort, setReasoningEffort] = useState("auto");
+  const [contextWindow, setContextWindow] = useState<number | null>(null);
   const [catalog, setCatalog] = useState<ModelCatalogResult | null>(null);
   const [refreshingModels, setRefreshingModels] = useState(false);
   const [modelFailure, setModelFailure] = useState<{
@@ -83,6 +85,15 @@ export function ModelPicker({
     : "auto";
   const effectiveEffort =
     thread?.reasoningEffort ?? defaults.reasoningEffort ?? "auto";
+  const effectiveContextWindow = thread?.contextWindow ?? null;
+  const contextOptions = useMemo(
+    () =>
+      contextWindowOptions(
+        selectedModel?.contextWindow ?? null,
+        contextWindow,
+      ),
+    [contextWindow, selectedModel?.contextWindow],
+  );
 
   useEffect(() => {
     if (!open || !selectedConnectionId) return;
@@ -151,7 +162,12 @@ export function ModelPicker({
 
   const apply = () => {
     if (!selectedConnectionId || !modelId) return;
-    onChange(selectedConnectionId, modelId, validReasoningEffort);
+    onChange(
+      selectedConnectionId,
+      modelId,
+      validReasoningEffort,
+      contextWindow,
+    );
     setOpen(false);
     setQuery("");
     setManualModel("");
@@ -185,6 +201,7 @@ export function ModelPicker({
           if (!open) {
             setModelId(effectiveModel ?? "");
             setReasoningEffort(effectiveEffort);
+            setContextWindow(effectiveContextWindow);
           }
           setOpen((current) => !current);
         }}
@@ -198,7 +215,12 @@ export function ModelPicker({
         <span>
           <small>{effectiveConnection?.label ?? "Automatic"}</small>
           <strong>{effectiveModel || "Configured model"}</strong>
-          <em>{effortLabel(effectiveEffort)}</em>
+          <em>
+            {effortLabel(effectiveEffort)} ·{" "}
+            {effectiveContextWindow
+              ? `${formatTokens(effectiveContextWindow)} context cap`
+              : "Auto context"}
+          </em>
         </span>
         <ChevronDown size={12} />
       </button>
@@ -232,6 +254,7 @@ export function ModelPicker({
                 setConnectionId(event.target.value);
                 setModelId("");
                 setReasoningEffort("auto");
+                setContextWindow(null);
                 setModelFailure(null);
                 setQuery("");
               }}
@@ -273,6 +296,7 @@ export function ModelPicker({
                   onClick={() => {
                     setModelId(model.id);
                     setReasoningEffort("auto");
+                    setContextWindow(null);
                   }}
                 >
                   <span>
@@ -321,6 +345,38 @@ export function ModelPicker({
             </div>
           </section>
 
+          <section className={styles.context} aria-label="Context window">
+            <div>
+              <strong>Context</strong>
+              <span>
+                Cap future Turns below the model&apos;s published window. Lower
+                caps compact history sooner.
+              </span>
+            </div>
+            <select
+              aria-label="Context window cap"
+              value={contextWindow ?? ""}
+              disabled={!selectedModel}
+              onChange={(event) =>
+                setContextWindow(
+                  event.target.value ? Number(event.target.value) : null,
+                )
+              }
+            >
+              <option value="">
+                Automatic
+                {selectedModel
+                  ? ` · ${formatTokens(selectedModel.contextWindow)}`
+                  : ""}
+              </option>
+              {contextOptions.map((value) => (
+                <option key={value} value={value}>
+                  {formatTokens(value)}
+                </option>
+              ))}
+            </select>
+          </section>
+
           <footer>
             <input
               value={manualModel}
@@ -333,6 +389,7 @@ export function ModelPicker({
               onClick={() => {
                 setModelId(manualModel.trim());
                 setReasoningEffort("auto");
+                setContextWindow(null);
               }}
               disabled={!selectedConnectionId || !manualModel.trim()}
             >
@@ -350,7 +407,7 @@ export function ModelPicker({
               type="button"
               className={styles.reset}
               onClick={() => {
-                onChange(null, null, null);
+                onChange(null, null, null, null);
                 setOpen(false);
               }}
             >
@@ -434,4 +491,16 @@ function formatTokens(value: number): string {
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
   if (value >= 1_000) return `${Math.round(value / 1_000)}K`;
   return String(value);
+}
+
+function contextWindowOptions(
+  published: number | null,
+  current: number | null,
+): number[] {
+  if (!published) return [];
+  const options = [32_000, 64_000, 128_000, 256_000, 512_000, 1_000_000].filter(
+    (value) => value < published,
+  );
+  if (current && current <= published) options.push(current);
+  return [...new Set(options)].sort((left, right) => left - right);
 }

--- a/desktop/src/features/workbench/useCodeWorkbench.test.tsx
+++ b/desktop/src/features/workbench/useCodeWorkbench.test.tsx
@@ -77,6 +77,7 @@ function thread(id: string): Thread {
     model: null,
     connectionId: null,
     reasoningEffort: null,
+    contextWindow: null,
     accessPresetOverride: null,
     workspacePath: `/workspace/${id}`,
     worktreePath: null,

--- a/desktop/src/generated/app-server.ts
+++ b/desktop/src/generated/app-server.ts
@@ -376,6 +376,7 @@ export interface ThreadStartParams {
   connectionId?: string;
   model?: string;
   reasoningEffort?: string;
+  contextWindow?: number;
   workspacePath?: string;
   parentThreadId?: string;
   agentPreset?: string;
@@ -404,6 +405,10 @@ export interface ThreadExecutionParams {
   connectionId: string | null;
   model: string | null;
   reasoningEffort: string | null;
+  /**
+   * Null clears the Session cap and follows the model's published context window.
+   */
+  contextWindow?: number | null;
 }
 export interface ThreadPermissionUpdateParams {
   threadId: string;
@@ -1247,6 +1252,10 @@ export interface Thread {
   model: string | null;
   connectionId: string | null;
   reasoningEffort: string | null;
+  /**
+   * Optional Session cap for future Turns. Null uses the model's published window.
+   */
+  contextWindow: number | null;
   /**
    * Session override. Null inherits the effective Settings default.
    */

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -81,6 +81,23 @@ While the model thinks, the status line shows the effort and the newest
 thought; `Ctrl+O`'s verbose mode prints full reasoning summaries when the
 provider exposes them.
 
+## Context window cap
+
+The model picker in Desktop can give the current Session a smaller context
+budget. The TUI exposes the same future-Turn setting directly:
+
+```text
+› /context 64k
+› /context auto     # return to the model's published window
+```
+
+The cap can only narrow the selected model's published context window. It does
+not claim that a model accepts more context than its catalog entry, and it must
+leave room for the configured generation limit. Each Turn freezes the effective
+window when it is accepted, so changing the Session later does not reinterpret
+an active or already queued Turn. A lower cap makes DeepCode compact long
+history sooner.
+
 ## What the turn footer tells you about cost
 
 ```text

--- a/protocol/app-server.schema.json
+++ b/protocol/app-server.schema.json
@@ -535,6 +535,15 @@
             "null"
           ]
         },
+        "contextWindow": {
+          "description": "Optional Session cap for future Turns. Null uses the model's published window.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 4096,
+          "maximum": 10000000
+        },
         "accessPresetOverride": {
           "description": "Session override. Null inherits the effective Settings default.",
           "oneOf": [
@@ -581,6 +590,7 @@
         "model",
         "connectionId",
         "reasoningEffort",
+        "contextWindow",
         "accessPresetOverride",
         "workspacePath",
         "worktreePath",
@@ -3660,6 +3670,11 @@
           "type": "string",
           "minLength": 1
         },
+        "contextWindow": {
+          "type": "integer",
+          "minimum": 4096,
+          "maximum": 10000000
+        },
         "workspacePath": {
           "type": "string"
         },
@@ -3795,6 +3810,15 @@
             "null"
           ],
           "minLength": 1
+        },
+        "contextWindow": {
+          "description": "Null clears the Session cap and follows the model's published context window.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 4096,
+          "maximum": 10000000
         }
       },
       "required": [

--- a/tests/app_server/test_server.py
+++ b/tests/app_server/test_server.py
@@ -768,10 +768,32 @@ def test_connection_and_model_protocol_is_shared_secret_safe_state(
                 "connectionId": "router-rpc",
                 "model": "moonshotai/kimi-k3",
                 "reasoningEffort": "high",
+                "contextWindow": 64_000,
             },
         )
-        + _request(7, "provider/remove", {"connectionId": "router-rpc"})
-        + _request(8, "shutdown", {})
+        + _request(
+            7,
+            "thread/execution/update",
+            {
+                "threadId": thread.id,
+                "connectionId": "router-rpc",
+                "model": "moonshotai/kimi-k3",
+                "reasoningEffort": "high",
+            },
+        )
+        + _request(
+            8,
+            "thread/execution/update",
+            {
+                "threadId": thread.id,
+                "connectionId": "router-rpc",
+                "model": "moonshotai/kimi-k3",
+                "reasoningEffort": "high",
+                "contextWindow": None,
+            },
+        )
+        + _request(9, "provider/remove", {"connectionId": "router-rpc"})
+        + _request(10, "shutdown", {})
     )
     sink = io.BytesIO()
 
@@ -813,7 +835,10 @@ def test_connection_and_model_protocol_is_shared_secret_safe_state(
     assert responses[6]["thread"]["connectionId"] == "router-rpc"
     assert responses[6]["thread"]["model"] == "moonshotai/kimi-k3"
     assert responses[6]["thread"]["reasoningEffort"] == "high"
-    assert responses[7]["removed"] is True
+    assert responses[6]["thread"]["contextWindow"] == 64_000
+    assert responses[7]["thread"]["contextWindow"] == 64_000
+    assert responses[8]["thread"]["contextWindow"] is None
+    assert responses[9]["removed"] is True
 
     persisted = json.loads((home / "deepcode_config.json").read_text())
     assert secret not in json.dumps(persisted)
@@ -823,6 +848,7 @@ def test_connection_and_model_protocol_is_shared_secret_safe_state(
     assert canonical.metadata["connection_id"] == "router-rpc"
     assert canonical.metadata["model"] == "moonshotai/kimi-k3"
     assert canonical.metadata["reasoning_effort"] == "high"
+    assert canonical.metadata["context_window"] is None
 
 
 def test_management_methods_round_trip_real_project_state(

--- a/tests/application/test_llm_configuration_service.py
+++ b/tests/application/test_llm_configuration_service.py
@@ -241,6 +241,31 @@ def test_execution_profile_freezes_generation_and_connection_revision(
     assert profile.temperature == 0.1
     assert "key" not in repr(profile.to_dict()).lower()
 
+    capped = resolver.execution_profile(
+        ExecutionSelection(
+            "router-b",
+            "moonshotai/kimi-k2.6",
+            context_window=64_000,
+        )
+    )
+    assert capped.context_window == 64_000
+    with pytest.raises(ConfigError, match="exceeds the published 256000"):
+        resolver.execution_profile(
+            ExecutionSelection(
+                "router-b",
+                "moonshotai/kimi-k2.6",
+                context_window=512_000,
+            )
+        )
+    with pytest.raises(ConfigError, match="must exceed the 8192 token generation"):
+        resolver.execution_profile(
+            ExecutionSelection(
+                "router-b",
+                "moonshotai/kimi-k2.6",
+                context_window=8_192,
+            )
+        )
+
     # Credential rotation is deliberately live and does not mutate the
     # persisted, secret-free execution profile.
     credentials.set("router-b", "rotated-key")

--- a/tests/application/test_turn_execution_profiles.py
+++ b/tests/application/test_turn_execution_profiles.py
@@ -117,6 +117,7 @@ def _application(
         connection_id="router-a",
         model="moonshotai/kimi-k2.5",
         reasoning_effort="low",
+        context_window=128_000,
     )
     return application, thread.id, sessions
 
@@ -155,6 +156,7 @@ def test_session_switch_rebuilds_runtime_but_preserves_history_and_turn_provenan
             connection_id="router-b",
             model="openai/gpt-5-mini",
             reasoning_effort="high",
+            context_window=64_000,
         )
         second = application.turns.start(thread_id, prompt="second")
         second_done = _wait(
@@ -168,9 +170,11 @@ def test_session_switch_rebuilds_runtime_but_preserves_history_and_turn_provenan
         assert first_done.turn.execution_profile.connection_id == "router-a"
         assert first_done.turn.execution_profile.model_id == "moonshotai/kimi-k2.5"
         assert first_done.turn.execution_profile.reasoning_effort == "low"
+        assert first_done.turn.execution_profile.context_window == 128_000
         assert second_done.turn.execution_profile.connection_id == "router-b"
         assert second_done.turn.execution_profile.model_id == "openai/gpt-5-mini"
         assert second_done.turn.execution_profile.reasoning_effort == "high"
+        assert second_done.turn.execution_profile.context_window == 64_000
         assert [profile.connection_id for profile in factory.profiles] == [
             "router-a",
             "router-b",
@@ -188,6 +192,7 @@ def test_session_switch_rebuilds_runtime_but_preserves_history_and_turn_provenan
         assert canonical.metadata["connection_id"] == "router-b"
         assert canonical.metadata["model"] == "openai/gpt-5-mini"
         assert canonical.metadata["reasoning_effort"] == "high"
+        assert canonical.metadata["context_window"] == 64_000
         assert (
             canonical.messages[0].metadata["executionProfile"]["connectionId"]
             == "router-a"
@@ -241,6 +246,7 @@ def test_active_goal_turn_keeps_snapshot_while_selection_updates_future_turns(
             connection_id="router-b",
             model="openai/gpt-5-mini",
             reasoning_effort="high",
+            context_window=64_000,
         )
         queued = application.turns.enqueue(
             thread_id,
@@ -252,11 +258,13 @@ def test_active_goal_turn_keeps_snapshot_while_selection_updates_future_turns(
         assert active_snapshot.turn.execution_profile.connection_id == "router-a"
         assert active_snapshot.turn.execution_profile.model_id == "moonshotai/kimi-k2.5"
         assert active_snapshot.turn.execution_profile.reasoning_effort == "low"
+        assert active_snapshot.turn.execution_profile.context_window == 128_000
         assert queued.turn.status is TurnStatus.QUEUED
         assert queued.turn.execution_profile is not None
         assert queued.turn.execution_profile.connection_id == "router-b"
         assert queued.turn.execution_profile.model_id == "openai/gpt-5-mini"
         assert queued.turn.execution_profile.reasoning_effort == "high"
+        assert queued.turn.execution_profile.context_window == 64_000
         assert active_snapshot.turn.goal_id == goal.id
         assert queued.turn.goal_id == goal.id
         assert application.turns.active_for_thread(thread_id).id == active.turn.id

--- a/tests/application/test_workflow_service.py
+++ b/tests/application/test_workflow_service.py
@@ -364,6 +364,7 @@ def test_workflow_freezes_session_model_for_every_paper2code_phase(
         connection_id="session-provider",
         model="openai/gpt-5.2",
         reasoning_effort="high",
+        context_window=64_000,
     )
     try:
         started = application.workflows.start(
@@ -380,6 +381,7 @@ def test_workflow_freezes_session_model_for_every_paper2code_phase(
             assert profile.connection_id == "session-provider"
             assert profile.model_id == "openai/gpt-5.2"
             assert profile.reasoning_effort == "high"
+            assert profile.context_window == 64_000
         captured = completed.run.input["executionProfiles"]
         assert captured["planning"] == runner.profiles["planning"].to_dict()
         assert captured["implementation"] == runner.profiles["implementation"].to_dict()

--- a/tests/persistence/test_database.py
+++ b/tests/persistence/test_database.py
@@ -136,6 +136,7 @@ def test_repositories_round_trip_every_p1_entity(tmp_path: Path) -> None:
         model="moonshotai/kimi-k2.6",
         connection_id="router-test",
         reasoning_effort="high",
+        context_window=64_000,
         workspace_path=str(tmp_path),
     )
     turn = Turn(

--- a/tests/persistence/test_web_access_migration.py
+++ b/tests/persistence/test_web_access_migration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 from core.domain import Project, Thread, ThreadMode, Turn
@@ -60,7 +61,7 @@ def test_v16_removes_the_abandoned_v15_web_policy_without_losing_rows(
 
 def test_fresh_v16_schema_has_no_web_search_policy_columns(tmp_path: Path) -> None:
     database = Database(tmp_path / "fresh.sqlite3")
-    database.initialize()
+    database.initialize(target_version=16)
 
     with database.read() as connection:
         assert current_version(connection) == 16
@@ -99,3 +100,23 @@ def test_v16_downgrade_restores_empty_v15_compatibility_columns(
         migrate(connection, 16)
         assert "web_search_mode_override" not in _column_names(connection, "threads")
         assert "web_access_policy_json" not in _column_names(connection, "turns")
+
+
+def test_v17_adds_reversible_session_context_window_column(tmp_path: Path) -> None:
+    database = Database(tmp_path / "context-window.sqlite3")
+    database.initialize(target_version=16)
+    thread, _turn = _seed_v14(database, tmp_path / "workspace")
+
+    with database.read() as connection:
+        migrate(connection, 17)
+        assert current_version(connection) == 17
+        assert "context_window" in _column_names(connection, "threads")
+        assert ThreadRepository(connection).get(thread.id) == thread
+
+        capped = replace(thread, context_window=64_000)
+        ThreadRepository(connection).update(capped)
+        assert ThreadRepository(connection).get(thread.id) == capped
+
+        migrate(connection, 16)
+        assert "context_window" not in _column_names(connection, "threads")
+        assert ThreadRepository(connection).get(thread.id) == thread

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -24,6 +24,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 import cli.tui.app as tui_app
+from cli.execution_options import parse_context_window
 from cli.transcript import TranscriptMode
 from cli.tui import animation, theme
 from cli.tui import text as text_fitting
@@ -80,6 +81,14 @@ class _ScriptedProvider:
 
 class _Profile:
     model = "fake-model"
+
+
+def test_context_window_parser_accepts_human_units_and_auto() -> None:
+    assert parse_context_window("32k") == 32_000
+    assert parse_context_window("1.5M") == 1_500_000
+    assert parse_context_window("auto") is None
+    with pytest.raises(ValueError, match="between"):
+        parse_context_window("2k")
 
 
 def _patch_provider(monkeypatch, provider):
@@ -1295,6 +1304,34 @@ def test_effort_switch_preserves_history_and_session_selection(
     stored = store.get_session(store.list_sessions()[0].session_id)
     assert stored is not None
     assert stored.metadata["reasoning_effort"] == "high"
+    assert [message.content for message in stored.messages] == [
+        "hello",
+        "first reply",
+        "continue",
+        "second reply",
+    ]
+
+
+def test_context_switch_preserves_history_and_session_selection(
+    monkeypatch, tmp_path, capsys
+):
+    rc, provider = _run_tui(
+        monkeypatch,
+        tmp_path,
+        "hello\n/context 64k\ncontinue\n/exit\n",
+        ["first reply", "second reply"],
+    )
+
+    assert rc == 0
+    assert provider.calls == 2
+    assert "context cap switched to 64000 tokens" in capsys.readouterr().out
+
+    from core.sessions.store import SessionStore
+
+    store = SessionStore(tmp_path / "sessions")
+    stored = store.get_session(store.list_sessions()[0].session_id)
+    assert stored is not None
+    assert stored.metadata["context_window"] == 64_000
     assert [message.content for message in stored.messages] == [
         "hello",
         "first reply",


### PR DESCRIPTION
## Description

Closes #153.

The reasoning controls from #161/#162 already cover the first half of the issue. This adds the remaining manual context-window control as a Session selection for future Turns, shared by Desktop and the interactive CLI.

## Behavior

- `null` / `auto` follows the selected model's published context window
- an explicit cap may only narrow that window and must leave room for the configured generation limit
- each accepted or queued Turn freezes the effective value in its immutable `ExecutionProfile`
- changing the Session later never reinterprets an active or already accepted Turn
- Paper2Code planning and implementation phases inherit the same Session cap

## Changes Made

- add the optional context cap to `ExecutionSelection`, canonical Session metadata, Thread projection, SQLite migration v17, and App Server protocol
- preserve older App Server clients that omit `contextWindow`; explicit `null` clears the override
- add context presets to the Desktop model picker and show the active cap on its trigger
- add `/context 64k` and `/context auto` to the TUI, including human `k`/`m` parsing
- document the control in the English and Chinese README and model guide
- add regression coverage for validation, frozen Turn profiles, workflows, persistence/migration, protocol compatibility, Desktop requests, and TUI persistence

## Verification

- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files
- focused Python verification — 20 passed
- persistence + reversible migration verification — 14 passed
- Desktop `npm test` — 31 files, 195 tests passed
- Desktop `npm run build`
- Desktop `npm run check:protocol`, `npm run typecheck`, and `npm run lint`

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated
- [x] Unit tests added