### PR TITLE
fix(providers): disable AsyncOpenAI keep-alive reuse to avoid SSL UNEXPECTED_EOF on idle-reaping gateways

### DIFF
--- a/core/providers/openai_compat.py
+++ b/core/providers/openai_compat.py
@@ -30,6 +30,8 @@ else:
         )
     from openai import AsyncOpenAI
 
+import httpx
+
 from core.providers.base import (
     LLMProvider,
     LLMResponse,
@@ -259,6 +261,12 @@ class OpenAICompatProvider(LLMProvider):
             default_headers=default_headers,
             max_retries=0,
             timeout=_get_default_request_timeout_s(),
+            # 禁用 keep-alive 连接复用：第三方网关(如 scnet)会回收空闲连接，
+            # 复用被回收的死连接会触发 SSL: UNEXPECTED_EOF_WHILE_READING。
+            # 每次请求新建连接，代价 ~50-100ms 握手，对 LLM 秒级请求可忽略。
+            http_client=httpx.AsyncClient(
+                limits=httpx.Limits(max_keepalive_connections=0),
+            ),
         )
 
         # Responses API circuit breaker: skip after repeated failures,


### PR DESCRIPTION
## Summary
This is the remaining, independent half of #198: disable keep-alive connection reuse in `OpenAICompatProvider`’s `AsyncOpenAI` client so third-party gateways (e.g. scnet) that reap idle connections don’t hand back a dead connection, which surfaces as `SSL: UNEXPECTED_EOF_WHILE_READING`.

The GLM-5.2 catalog entry from #198 was already merged upstream as a standalone commit credited to me (`329e98f0`), so this PR contains only the keep-alive fix.

## Changes
- `core/providers/openai_compat.py`: pass `http_client=httpx.AsyncClient(limits=httpx.Limits(max_keepalive_connections=0))` to `AsyncOpenAI` (+8 lines). New connection per request (~50–100 ms handshake) is negligible for LLM-second-scale calls.

## Tests
- `python -m py_compile core/providers/openai_compat.py` ✓
- module import smoke ✓ (httpx available)
- full CI pending

## Notes
- Based on current `upstream/main` (`c0a6a3c`); single file, no CLAUDE.md / .gitleaksignore changes.

Related: #198