### PR TITLE
fix(cli,hooks): UTF-8 robustness on Windows (GBK) locales

### DIFF
--- a/cli/loop_cli.py
+++ b/cli/loop_cli.py
@@ -41,6 +41,7 @@ from cli.tui.renderer import EventRenderer
 from core.application.errors import ApplicationError
 from core.config import ConfigError
 from core.domain.thread_goal import ThreadGoalStatus
+from core.platform_compat import configure_utf8_stdio
 
 _STATUS_STYLE = {
     "succeeded": "bold green",
@@ -161,6 +162,9 @@ def _run(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Windows consoles default to GBK/cp936; rich and model output emit UTF-8.
+    # Reconfigure early so headless runs never crash rendering non-GBK text.
+    configure_utf8_stdio()
     parser = argparse.ArgumentParser(
         prog="deepcode loop",
         description="Run a durable Goal on the shared ordinary-Turn runtime.",

--- a/core/harness/hooks/discovery.py
+++ b/core/harness/hooks/discovery.py
@@ -103,7 +103,7 @@ def _load_hook_events(path: Path, warnings: list[str]) -> dict | None:
     if not path.is_file():
         return None
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         warnings.append(f"failed to read hooks config {path}: {exc}")
         return None


### PR DESCRIPTION
## Summary
Windows defaults the console to GBK/cp936. Two small fixes make the CLI robust to non-UTF-8 locales; each is a no-op where the locale is already UTF-8.

## Changes
1. **cli/loop_cli.py** — headless `deepcode loop` now calls `core.platform_compat.configure_utf8_stdio()` before the parser/Console are set up. Fixes `UnicodeEncodeError` when rich or model output renders non-GBK text (the recent `dsh` headless runs crashed on Windows otherwise).
2. **core/harness/hooks/discovery.py** — read `hooks.json` / `.claude/settings.json` explicitly as UTF-8 instead of the locale default, so a GBK-locale console does not mis-decode (or raise on) non-GBK bytes in a UTF-8 hooks config.

## Tests
- Both changed modules import cleanly against this branch.
- `ruff check` + `ruff format --check` pass under the repo-pinned ruff (pre-commit rev v0.15.21).
- No behavior change on UTF-8-locale systems; CI will run the full suite.

## Notes
Two independent commits, one logical concern (UTF-8 robustness). The CLI hunk is taken verbatim from our local working tree fix for the same crash.