### PR TITLE
test: synchronize legacy automation race before interruption

### DIFF
--- a/tests/application/test_automation_goal_runs.py
+++ b/tests/application/test_automation_goal_runs.py
@@ -1041,6 +1041,13 @@ def test_legacy_unreserved_turn_is_never_adopted_as_automation_initial_turn(
         assert foreign.prompt == "A legacy client won the race"
         assert foreign.id != execution.run.turn_id
 
+        # Submission can return before the Agent consumes its scripted step.
+        # Interrupt only after that step is claimed, so the Automation receives
+        # the second (completing) step rather than the foreign Turn's gate.
+        _wait_until(
+            lambda: factory.started_prompts == [foreign.prompt],
+            "foreign Agent to consume its scripted step",
+        )
         accepted, interrupted = application.turns.interrupt(
             automation.thread_id,
             foreign.id,


### PR DESCRIPTION
The legacy-client automation race test could interrupt its foreign Turn before the scripted Agent claimed the first step. The subsequent Automation then consumed that gated step and timed out instead of completing. This caused Python 3.12 to fail on the first main run after #212, despite the PR checks passing.

Wait for the foreign Agent to claim its step before interrupting it. All existing assertions remain, including refusal to adopt the foreign Turn and eventual completion with the Automation’s own Turn. Only seven test lines change; production code and timeouts are unchanged.

Validation:
- Reproduced the original timeout by delaying the foreign Agent start by 0.2 seconds with a local pytest plugin.
- All 32 automation goal-run tests pass with that delay applied.
- The affected test passes 20 consecutive independent delayed-start runs.
- Pre-commit checks pass.

This follow-up will be merged only after its applicable CI checks pass.
