### PR TITLE
feat(loop): prompt cue guidance for structured/stepwise output

### DIFF
--- a/core/loop/cue.py
+++ b/core/loop/cue.py
@@ -1,0 +1,63 @@
+"""P3-A (GenAI lesson 04): prompt cue guidance for structured / stepwise output.
+
+Lesson 04 (prompt engineering) stresses that explicit *cues* — short
+signposts telling the model what shape the answer should take — cut down on
+free-form filler and keep multi-step work on rails. DeepCode already carries
+heavy system-prompt scaffolding; this module adds one *thin, model-facing*
+cue injected as transient turn context on the routed request.
+
+Design constraints
+-----------------
+- The cue must NOT be appended to every provider request. The runner replays
+  the routed request view as the prefix of its compaction summarizer call
+  (the dsh rule — prefix/KV cache reuse). Injecting different text on the
+  compaction path would desynchronize that prefix. We therefore attach the
+  cue via ``transient_context_messages``, which the runner applies to routed
+  requests and never to the summarizer prefix.
+- The cue is advisory prose, not a hard schema: it must never contradict a
+  caller-provided JSON schema or structured-output mode. It only biases
+  *default* behavior (stepwise work, cite-before-claim, no filler).
+
+Enable: env ``DEEPCODE_PROMPT_CUE`` (default on). Set ``0``/``false``/``off``
+to disable.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+_CUE_TEXT = (
+    "Work stepwise: state each step as you take it, use the available tools "
+    "to verify claims before asserting them, and keep the final answer "
+    "tight — no restating the task, no filler. If you cite a retrieved "
+    "memory or tool result, reference it by its label ([n] / tool name)."
+)
+
+
+def prompt_cue_enabled() -> bool:
+    """Whether the prompt cue is on (env ``DEEPCODE_PROMPT_CUE``; default on)."""
+    value = os.environ.get("DEEPCODE_PROMPT_CUE", "").strip().lower()
+    if not value:
+        return True
+    return value not in {"0", "false", "off", "no"}
+
+
+def build_cue_context() -> tuple[dict[str, Any], ...]:
+    """Transient turn-context messages carrying the cue, or empty when off.
+
+    Returns a single ``user``-role message so the runner's
+    ``_with_transient_context`` places it immediately before the canonical
+    user request (user-priority turn context), never inside system-level
+    instructions.
+    """
+    if not prompt_cue_enabled():
+        return ()
+    return ({"role": "user", "content": _CUE_TEXT},)
+
+
+__all__ = [
+    "_CUE_TEXT",
+    "build_cue_context",
+    "prompt_cue_enabled",
+]


### PR DESCRIPTION
## 设计说明

**问题**：agent 输出经常包含 free-form filler（复述任务、无关客套），多步任务容易脱轨。系统 prompt 已经很重，不适合再往里面堆指令。

**解法**：一条简短的 prompt cue——在 routed request 上附加 transient context 消息，提示模型 stepwise 工作、先验证再断言、引用工具结果时带标签。

**关键设计决策**：
- 通过 `transient_context_messages` 注入，**不会**出现在 compaction summarizer 的 prefix 中，避免破坏 prefix/KV cache 对齐
- 是 advisory prose 而非硬 schema——永远不会与调用方提供的 JSON schema 或 structured-output 模式冲突
- 环境变量 `DEEPCODE_PROMPT_CUE` 开关（默认开，设 `0/false/off` 关闭）

**边界情况**：
- 关闭时返回空 tuple，完全不改变现有行为
- 只有一条 user-role 消息，确保被放在 canonical user request 之前

**测试建议**：验证 `build_cue_context()` 开关逻辑 + 返回结构；`prompt_cue_enabled()` 的环境变量解析
