### PR TITLE
fix(security): add screen_command defense-in-depth to command_executor (#128)

### DIFF
--- a/tools/command_executor.py
+++ b/tools/command_executor.py
@@ -366,8 +366,7 @@ async def execute_single_command(
             return [
                 types.TextContent(
                     type="text",
-                    text=f"🚫 Command BLOCKED: {command}
-Reason: {blocked_reason}"
+                    text=f"🚫 Command BLOCKED: {command}\nReason: {blocked_reason}",
                 )
             ]
 

--- a/tools/command_executor.py
+++ b/tools/command_executor.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional, Tuple
 
 from core.platform_compat import configure_utf8_stdio, subprocess_env
 from core.harness.sandbox import build_exec_command
+from core.harness.command_guard import screen_command
 
 configure_utf8_stdio()
 
@@ -270,6 +271,14 @@ async def execute_command_batch(
         cwd_path = Path(working_directory)
 
         for i, command in enumerate(command_lines, 1):
+            # Defense-in-depth: screen obviously destructive commands
+            blocked_reason = screen_command(command)
+            if blocked_reason is not None:
+                results.append(f"🚫 Command {i} BLOCKED: {command}")
+                results.append(f"   Reason: {blocked_reason}")
+                stats["failed"] += 1
+                continue
+
             native = _try_native_execute(command, cwd_path)
             if native is not None:
                 rc, out, err = native
@@ -351,6 +360,17 @@ async def execute_single_command(
         执行结果 / Execution result
     """
     try:
+        # Defense-in-depth: screen obviously destructive commands
+        blocked_reason = screen_command(command)
+        if blocked_reason is not None:
+            return [
+                types.TextContent(
+                    type="text",
+                    text=f"🚫 Command BLOCKED: {command}
+Reason: {blocked_reason}"
+                )
+            ]
+
         cwd_path = Path(working_directory)
         cwd_path.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary

Adds screen_command() defense-in-depth to command_executor.py, matching the existing pattern in code_implementation_server.py.

## Why

Closes #128 - execute_commands and execute_single_command had no pre-execution screening, while code_implementation_server.py already had it.

## Changes

1. Import screen_command from core.harness.command_guard
2. Add check in execute_commands loop before native/sandbox execution
3. Add check at top of execute_single_command function

## Testing

pytest tests/test_command_guard.py -v