### PR TITLE
feat(providers): put LLM provider endpoints under an egress policy

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -43,6 +43,12 @@ from pydantic_settings import BaseSettings
 from core.agent_runtime.tools.mcp import MCPServerConfig
 from core.mcp.models import McpServerDefinition
 from core.providers.base import GenerationSettings, LLMProvider
+from core.providers.egress import (
+    WARN,
+    describe_denial,
+    evaluate_provider_egress,
+    resolve_egress_policy,
+)
 from core.providers.protocol_config import (
     ProviderCompat,
     ProviderProtocol,
@@ -265,6 +271,42 @@ class ConnectionProfileConfig(_Base):
         return self
 
 
+class EgressPolicyConfig(_Base):
+    """Optional model-egress policy for LLM provider endpoints (P0-1).
+
+    Why: ``apiBase`` *is* the trust boundary. Whoever terminates TLS for an
+    endpoint reads every prompt and tool result in plaintext and can rewrite
+    the tool calls in the response, so the same hostname policy that already
+    guards WebFetch is applied to model traffic.
+
+    Accepted keys (camelCase; snake_case also accepted):
+
+    - ``allowedDomains``: list of domains. Empty means "no allow-list
+      configured" — every host is allowed unless blocked. That is the existing
+      meaning of an empty allow-list in ``core/network/hostnames.py`` and is
+      preserved so an unconfigured install keeps working after upgrade.
+    - ``blockedDomains``: list of domains. Deny wins over allow; matching is
+      exact-or-subdomain.
+    - ``mode``: ``enforce`` (default) or ``warn``. ``warn`` evaluates and logs
+      but never blocks, so the policy can be rolled out against a live setup.
+
+    Environment overrides, taken as a union with the config lists (block still
+    wins, and an env list cannot un-block what the config blocks):
+
+    - ``DEEPCODE_EGRESS_ALLOW_DOMAINS`` — comma-separated.
+    - ``DEEPCODE_EGRESS_BLOCK_DOMAINS`` — comma-separated.
+    - ``DEEPCODE_EGRESS_MODE`` — ``enforce`` (default) or ``warn``.
+
+    A project-level ``deepcode_config.json`` cannot loosen this: the project
+    layer (``_project_runtime_layer``) drops every provider routing field
+    except a literal ``apiKey``, so ``providers.egress`` stays user-owned.
+    """
+
+    allowed_domains: list[str] = Field(default_factory=list)
+    blocked_domains: list[str] = Field(default_factory=list)
+    mode: Literal["enforce", "warn"] | None = None
+
+
 class ProvidersConfig(_Base):
     """Per-provider connection blocks. Add new providers by extending here
     and adding the matching :class:`~core.providers.registry.ProviderSpec`.
@@ -284,6 +326,9 @@ class ProvidersConfig(_Base):
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     ollama: ProviderConfig = Field(default_factory=ProviderConfig)
     profiles: dict[str, ConnectionProfileConfig] = Field(default_factory=dict)
+    # Not a provider block: resolves by name from the registry, never
+    # `getattr(providers, spec.name)`, so it cannot shadow a provider entry.
+    egress: EgressPolicyConfig = Field(default_factory=EgressPolicyConfig)
 
 
 # ---------------------------------------------------------------------------
@@ -932,6 +977,56 @@ def _resolve_spec_for_phase(
     return matched_cfg, spec, chosen_model, settings
 
 
+def _enforce_provider_egress(
+    config: DeepCodeConfig,
+    spec: ProviderSpec,
+    api_base: str | None,
+    *,
+    phase: str,
+) -> None:
+    """Apply the model-egress policy to one resolved provider endpoint (P0-1).
+
+    Called exactly once per provider construction, so it must stay cheap: the
+    decision is a string comparison, not a request-time cost. Policy lives in
+    ``providers.egress`` and the ``DEEPCODE_EGRESS_*`` env vars; see
+    :class:`EgressPolicyConfig`.
+
+    ``enforce`` raises :class:`ConfigError` (the convention of this module for
+    user-fixable configuration problems, and still a ``ValueError`` for legacy
+    handlers). ``warn`` logs the same message and continues, which is what lets
+    an operator measure a live setup before turning the gate on.
+    """
+
+    policy = resolve_egress_policy(config)
+    endpoint_class = spec.resolve_endpoint_class(api_base)
+    decision = evaluate_provider_egress(
+        api_base,
+        endpoint_class=endpoint_class,
+        allowed_domains=policy.allowed_domains,
+        blocked_domains=policy.blocked_domains,
+    )
+    if decision.allowed:
+        logger.trace(
+            "Model egress ok: provider={} host={} endpoint_class={}",
+            spec.name,
+            decision.host,
+            decision.endpoint_class,
+        )
+        return
+
+    message = describe_denial(
+        provider=spec.name,
+        phase=phase,
+        decision=decision,
+        policy=policy,
+        api_base=api_base,
+    )
+    if policy.mode == WARN:
+        logger.warning(message)
+        return
+    raise ConfigError(message)
+
+
 def make_llm_provider(
     config: DeepCodeConfig,
     *,
@@ -945,6 +1040,10 @@ def make_llm_provider(
     :class:`~core.providers.registry.ProviderSpec` decides which backend
     (``openai_compat``, ``anthropic``, ...) is instantiated. ``GenerationSettings``
     are derived from the resolved phase settings.
+
+    The resolved endpoint passes the model-egress policy once, here — this
+    function is the single construction point for LLM providers, so gating it
+    covers every backend without teaching each SDK client about policy.
     """
     provider_cfg, spec, chosen_model, settings = _resolve_spec_for_phase(
         config, phase, provider_override=provider_name, model_override=model
@@ -974,6 +1073,9 @@ def make_llm_provider(
         )
 
     effective_base = api_base or spec.default_api_base or None
+    # P0-1: one egress decision per provider construction. Placed after
+    # `effective_base` so the spec's own default endpoint is judged too.
+    _enforce_provider_egress(config, spec, effective_base, phase=phase)
 
     if backend == "anthropic":
         from core.providers.anthropic import AnthropicProvider
@@ -1021,6 +1123,7 @@ __all__ = [
     "ManualModelConfig",
     "DeepCodeConfig",
     "DocumentSegmentationConfig",
+    "EgressPolicyConfig",
     "LLMLoggerConfig",
     "LoggerConfig",
     "LoggerGlobalFile",

--- a/core/providers/egress.py
+++ b/core/providers/egress.py
@@ -1,0 +1,353 @@
+"""Model-egress policy for LLM provider endpoints (P0-1).
+
+Why this module exists
+----------------------
+
+``core/network/hostnames.py`` + ``core/network/safe_http.py`` already answer
+"which hosts may this agent *fetch*" and are used by the web tool. Model traffic
+bypassed them completely: ``api_base`` was an unvalidated string handed straight
+to the OpenAI/Anthropic SDK. That is the larger exposure of the two — the tool
+result fetched from a website lands in the *next* request, so the endpoint that
+receives prompts also receives everything the agent read. Whoever terminates TLS
+for that endpoint (the vendor, a gateway, a reseller, or a hop the operator did
+not configure) holds plaintext for every prompt and every tool result, and can
+rewrite tool calls on the way back.
+
+The policy therefore answers one question at provider-construction time: *is
+this endpoint host one the operator allows?* The answer is a value, not an
+exception, so a caller can decide to block or merely record it.
+
+Layering
+--------
+
+- :func:`evaluate_provider_egress` is the pure kernel: no I/O, no environment,
+  no config import. It is the part worth testing exhaustively.
+- :func:`resolve_egress_policy` / :func:`egress_mode` are the thin impure edge
+  that reads the environment and the DEEPCODE config.
+
+Fail-closed semantics, inherited from :func:`is_domain_allowed`: an *empty*
+allow-list means "no allow-list configured", i.e. every host is allowed unless
+it is blocked. That is the historical meaning of an empty allow-list in this
+repo (``core/harness/tools/web.py``) and it is preserved on purpose — turning an
+unconfigured policy into "deny everything" would break every working setup on
+upgrade. Configure an allow-list to get a closed policy.
+
+Modes
+-----
+
+``DEEPCODE_EGRESS_MODE=warn`` exists so an operator can roll the policy out
+against a live configuration without breaking it: every decision is computed and
+logged, but nothing is blocked. Use it to discover which endpoints a setup
+actually talks to, then switch to ``enforce`` (the default). ``warn`` is
+deliberately not sticky: an unset or unrecognized value resolves to ``enforce``,
+so a typo cannot silently disable the gate.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from core.network.hostnames import is_domain_allowed
+
+#: Mode that blocks a denied endpoint by raising in ``make_llm_provider``.
+ENFORCE = "enforce"
+#: Mode that records a denied endpoint without blocking (rollout aid).
+WARN = "warn"
+EGRESS_MODES: tuple[str, ...] = (ENFORCE, WARN)
+
+MODE_ENV = "DEEPCODE_EGRESS_MODE"
+ALLOW_ENV = "DEEPCODE_EGRESS_ALLOW_DOMAINS"
+BLOCK_ENV = "DEEPCODE_EGRESS_BLOCK_DOMAINS"
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+@dataclass(frozen=True)
+class EgressDecision:
+    """Outcome of evaluating one provider endpoint against the egress policy.
+
+    ``host`` is ``None`` when there was no endpoint to judge (the SDK will use
+    its own default) or when the base could not be parsed. ``endpoint_class``
+    is echoed back so a caller can report *what kind* of endpoint was denied
+    without re-deriving it. ``reason`` is human-readable and only set when
+    ``allowed`` is ``False``.
+    """
+
+    allowed: bool
+    host: str | None
+    endpoint_class: str
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class EgressPolicy:
+    """Resolved policy: the two domain lists plus the effective mode.
+
+    Kept as a value object so the decision function stays pure — callers pass
+    the lists in rather than reaching for the environment themselves.
+    """
+
+    allowed_domains: tuple[str, ...] = ()
+    blocked_domains: tuple[str, ...] = ()
+    mode: str = ENFORCE
+
+
+def parse_domain_list(raw: str | Iterable[str] | None) -> tuple[str, ...]:
+    """Normalize a comma-separated string or iterable of domains.
+
+    Trims whitespace, drops empty entries, lowercases, and de-duplicates while
+    preserving order. Deliberately does *not* validate the syntax — that is
+    :func:`is_domain_allowed`'s job at decision time, where an invalid entry
+    fails closed rather than being silently discarded at parse time.
+    """
+
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        candidates: Iterable[Any] = raw.split(",")
+    elif isinstance(raw, Iterable):
+        candidates = raw
+    else:
+        return ()
+
+    seen: dict[str, None] = {}
+    for item in candidates:
+        if not isinstance(item, str):
+            continue
+        value = item.strip().lower()
+        if value:
+            seen.setdefault(value, None)
+    return tuple(seen)
+
+
+def _normalize_mode(raw: str | None) -> str | None:
+    """Return a known mode, or ``None`` when unset/unrecognized.
+
+    An unknown value resolves to ``None`` so the caller falls back to
+    ``enforce``; a typo must not be able to downgrade the gate to ``warn``.
+    """
+
+    if not raw or not isinstance(raw, str):
+        return None
+    value = raw.strip().lower()
+    return value if value in EGRESS_MODES else None
+
+
+def egress_mode() -> str:
+    """Effective egress mode from the environment (``enforce`` by default).
+
+    Config-provided mode is handled by :func:`resolve_egress_policy`; this
+    accessor is for callers that only need the process-wide switch.
+    """
+
+    return _normalize_mode(os.environ.get(MODE_ENV)) or ENFORCE
+
+
+def _policy_field(source: Any, *names: str) -> Any:
+    """Read the first present of ``names`` from a mapping or an object."""
+
+    if isinstance(source, Mapping):
+        for name in names:
+            if name in source:
+                return source[name]
+        return None
+    for name in names:
+        value = getattr(source, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _policy_from_config(config_or_none: Any) -> EgressPolicy:
+    """Read ``providers.egress`` if the object looks like a DEEPCODE config.
+
+    Tolerant by design: a ``None``, a partially built config, or a plain dict
+    (tests, JSON round-trips) must not raise — a broken policy read would turn
+    an unconfigured setup into a hard failure.
+    """
+
+    if config_or_none is None:
+        return EgressPolicy()
+    try:
+        providers = _policy_field(config_or_none, "providers")
+        if providers is None:
+            return EgressPolicy()
+        egress = _policy_field(providers, "egress")
+        if egress is None:
+            return EgressPolicy()
+        allowed = parse_domain_list(
+            _policy_field(egress, "allowed_domains", "allowedDomains")
+        )
+        blocked = parse_domain_list(
+            _policy_field(egress, "blocked_domains", "blockedDomains")
+        )
+        mode = _normalize_mode(_policy_field(egress, "mode"))
+    except (AttributeError, TypeError, ValueError):  # pragma: no cover - defensive
+        # Never let an unreadable policy turn provider setup into a crash: a
+        # broken config object yields the neutral (unconfigured) policy, which
+        # the mode switch still governs.
+        return EgressPolicy()
+    return EgressPolicy(
+        allowed_domains=allowed,
+        blocked_domains=blocked,
+        mode=mode or ENFORCE,
+    )
+
+
+def resolve_egress_policy(config_or_none: Any = None) -> EgressPolicy:
+    """Merge the configured policy with environment overrides.
+
+    Environment lists *extend* the config lists rather than replacing them, and
+    a block still beats an allow. Either source can therefore only ever tighten
+    the policy from the other's point of view — an env var cannot be used to
+    un-block a host the config blocks, which keeps a stray shell variable from
+    silently re-opening a closed policy.
+
+    ``DEEPCODE_EGRESS_MODE`` wins over the config mode; an unrecognized value
+    falls back to ``enforce`` (see :func:`egress_mode`).
+    """
+
+    from_config = _policy_from_config(config_or_none)
+    env_allowed = parse_domain_list(os.environ.get(ALLOW_ENV))
+    env_blocked = parse_domain_list(os.environ.get(BLOCK_ENV))
+    env_mode = _normalize_mode(os.environ.get(MODE_ENV))
+    return EgressPolicy(
+        allowed_domains=parse_domain_list((*from_config.allowed_domains, *env_allowed)),
+        blocked_domains=parse_domain_list((*from_config.blocked_domains, *env_blocked)),
+        mode=env_mode or from_config.mode,
+    )
+
+
+def evaluate_provider_egress(
+    api_base: str | None,
+    *,
+    endpoint_class: str = "unknown",
+    allowed_domains: tuple[str, ...] | Iterable[str] = (),
+    blocked_domains: tuple[str, ...] | Iterable[str] = (),
+) -> EgressDecision:
+    """Decide whether model traffic may be sent to ``api_base``.
+
+    Pure: no I/O, no environment, no config import. Rules, in order:
+
+    1. No ``api_base`` at all -> allowed. The SDK falls back to its own default
+       endpoint, which this function cannot see; pretending to police it would
+       produce a policy that lies about what it covers. A spec that cares must
+       set ``default_api_base`` (``make_llm_provider`` resolves it before
+       calling here, so in practice this branch is the truly endpointless case).
+    2. Unparseable, or a scheme other than http/https -> denied. A model
+       endpoint that is not plain HTTP(S) cannot be reasoned about at all.
+    3. Otherwise the hostname goes through
+       :func:`core.network.hostnames.is_domain_allowed`, so a block match or a
+       configured-but-non-matching allow-list denies with a reason naming the
+       host.
+    """
+
+    base = api_base.strip() if isinstance(api_base, str) else ""
+    if not base:
+        return EgressDecision(
+            allowed=True, host=None, endpoint_class=endpoint_class, reason=None
+        )
+
+    try:
+        parsed = urlparse(base)
+        scheme = (parsed.scheme or "").lower()
+        host = parsed.hostname
+    except ValueError as exc:
+        return EgressDecision(
+            allowed=False,
+            host=None,
+            endpoint_class=endpoint_class,
+            reason=(
+                f"api_base {base!r} is not a parseable URL ({exc}); "
+                "fix providers.<name>.apiBase or unset it"
+            ),
+        )
+
+    if scheme not in _ALLOWED_SCHEMES:
+        return EgressDecision(
+            allowed=False,
+            host=host,
+            endpoint_class=endpoint_class,
+            reason=(
+                f"api_base {base!r} uses scheme {scheme or '<none>'!r}; only "
+                "http/https model endpoints are allowed"
+            ),
+        )
+
+    if not host:
+        return EgressDecision(
+            allowed=False,
+            host=None,
+            endpoint_class=endpoint_class,
+            reason=f"api_base {base!r} has no hostname",
+        )
+
+    allowed = parse_domain_list(allowed_domains)
+    blocked = parse_domain_list(blocked_domains)
+    if is_domain_allowed(host, allowed_domains=allowed, blocked_domains=blocked):
+        return EgressDecision(
+            allowed=True, host=host, endpoint_class=endpoint_class, reason=None
+        )
+
+    # Distinguish the two failure shapes for the operator: "you blocked this"
+    # and "this is not on your allow-list" need different fixes. With an empty
+    # allow-list `is_domain_allowed` returns True, so this call only reports
+    # False for an actual block match.
+    if not is_domain_allowed(host, blocked_domains=blocked):
+        detail = "is blocked by the egress block-list"
+    else:
+        detail = "is not on the egress allow-list"
+    return EgressDecision(
+        allowed=False,
+        host=host,
+        endpoint_class=endpoint_class,
+        reason=f"host {host!r} {detail} (endpoint_class={endpoint_class})",
+    )
+
+
+def describe_denial(
+    *,
+    provider: str,
+    phase: str,
+    decision: EgressDecision,
+    policy: EgressPolicy,
+    api_base: str | None,
+) -> str:
+    """Build the actionable message used when a provider endpoint is denied.
+
+    Names the host and endpoint class, then states the exact knobs that would
+    allow it (env vars and the config path), plus the rollout escape hatch.
+    """
+
+    return (
+        f"Model egress blocked for provider '{provider}' (phase '{phase}'): "
+        f"{decision.reason}. api_base={api_base!r}. "
+        "To allow it, add the domain to DEEPCODE_EGRESS_ALLOW_DOMAINS "
+        "(comma-separated) or providers.egress.allowedDomains in "
+        "deepcode_config.json; if it is blocked, remove it from "
+        f"{BLOCK_ENV} / providers.egress.blockedDomains. "
+        f"Set {MODE_ENV}=warn to log denials without blocking. "
+        f"(effective policy: allowed={list(policy.allowed_domains)}, "
+        f"blocked={list(policy.blocked_domains)}, mode={policy.mode})"
+    )
+
+
+__all__ = [
+    "ALLOW_ENV",
+    "BLOCK_ENV",
+    "EGRESS_MODES",
+    "ENFORCE",
+    "MODE_ENV",
+    "WARN",
+    "EgressDecision",
+    "EgressPolicy",
+    "describe_denial",
+    "egress_mode",
+    "evaluate_provider_egress",
+    "parse_domain_list",
+    "resolve_egress_policy",
+]

--- a/core/providers/registry.py
+++ b/core/providers/registry.py
@@ -8,6 +8,14 @@ Adding a new provider:
   1. Add a ``ProviderSpec`` to ``PROVIDERS`` below (order = match priority).
   2. If you need a new backend, instantiate it in
      :func:`core.config.make_llm_provider` based on ``spec.backend``.
+  3. Classify the endpoint with ``endpoint_class`` (see :data:`ENDPOINT_CLASSES`).
+
+Endpoint classification (P0-1) exists because ``api_base`` *is* the trust
+boundary: whoever terminates TLS for it reads every prompt and tool result in
+plaintext, and can rewrite tool calls in the response. The classification is
+descriptive, not a verdict — the egress allow/block lists decide — but it is
+what a denial message and the provider audit trail report, so it must not
+flatter a third-party relay into looking first-party.
 """
 
 from __future__ import annotations
@@ -15,8 +23,75 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import urlparse
 
 _SNAKE_PATTERN = re.compile(r"(?<!^)(?=[A-Z])")
+
+ENDPOINT_CLASSES: tuple[str, ...] = (
+    # The model vendor's own API surface: ``api.deepseek.com``,
+    # ``generativelanguage.googleapis.com``, ``api.anthropic.com``. Not a
+    # trust guarantee (the vendor is still the largest single observer), but
+    # there is no *intermediary* in the path.
+    "first_party",
+    # A router that fans one base_url out to many vendors and re-encodes the
+    # request per vendor (OpenRouter / Requesty / Forge). Multi-tenant by
+    # design: the same operator sees traffic for every model you use.
+    "gateway",
+    # A hosted reseller or third-party mirror of one vendor's API
+    # (Zhipu/DashScope/MiniMax and friends). Looks first-party from the wire
+    # format, but the endpoint is somebody else's deployment.
+    "aggregator",
+    # Loopback/LAN endpoint the operator runs (Ollama, vLLM).
+    "local",
+    # No claim about the operator. Callers must treat this as untrusted.
+    "unknown",
+)
+
+DEFAULT_ENDPOINT_CLASS = "unknown"
+
+# Hosts that clearly belong to the machine or its LAN. Only used to classify a
+# `custom` endpoint the operator pointed at something local; the raw hostname
+# still goes through the allow/block policy like any other.
+_LOCAL_HOSTNAMES = frozenset({"localhost", "::1", "0.0.0.0", "host.docker.internal"})
+_LOCAL_HOST_SUFFIXES = (".localhost", ".local", ".internal")
+_LOOPBACK_PREFIX = "127."
+
+
+def endpoint_host(api_base: str | None) -> str | None:
+    """Extract the lowercased hostname from an API base URL, or ``None``.
+
+    Returns ``None`` for a missing or malformed base; callers treat that as
+    "cannot classify", never as a match.
+    """
+
+    if not api_base or not isinstance(api_base, str):
+        return None
+    try:
+        host = (urlparse(api_base.strip()).hostname or "").lower().rstrip(".")
+    except ValueError:
+        # Malformed URL (bad port, unbalanced IPv6 brackets) — the egress check
+        # rejects it with a reason of its own.
+        return None
+    return host or None
+
+
+def host_looks_local(api_base: str | None) -> bool:
+    """Best-effort "this endpoint is not on the public internet" check.
+
+    A dotless hostname (``http://ollama:11434/v1``) counts as local: public DNS
+    names the operator would route model traffic to always have a suffix, and
+    a dotted IP-less name is the LAN case we care about. Loopback/IPv6-loopback
+    and ``*.local``/``*.internal`` are always local.
+    """
+
+    host = endpoint_host(api_base)
+    if not host:
+        return False
+    if host in _LOCAL_HOSTNAMES:
+        return True
+    if host.startswith(_LOOPBACK_PREFIX) or host.endswith(_LOCAL_HOST_SUFFIXES):
+        return True
+    return "." not in host
 
 
 def _to_snake(name: str) -> str:
@@ -25,7 +100,13 @@ def _to_snake(name: str) -> str:
 
 @dataclass(frozen=True)
 class ProviderSpec:
-    """One LLM provider's metadata."""
+    """One LLM provider's metadata.
+
+    ``is_gateway`` is the pre-existing boolean ("this endpoint is not the model
+    vendor") and is kept because callers/tests read it. ``endpoint_class`` is
+    its finer-grained successor; see :data:`ENDPOINT_CLASSES` for the values and
+    :meth:`resolve_endpoint_class` for how an unset class is derived.
+    """
 
     name: str
     keywords: tuple[str, ...]
@@ -33,6 +114,10 @@ class ProviderSpec:
     display_name: str = ""
     backend: str = "openai_compat"
     is_gateway: bool = False
+    # Empty means "not classified here" — `resolve_endpoint_class()` derives a
+    # default from `is_gateway`/`is_local`/`requires_api_base` so an entry
+    # added without a classification still fails closed as `unknown`.
+    endpoint_class: str = ""
     is_local: bool = False
     detect_by_key_prefix: str = ""
     detect_by_base_keyword: str = ""
@@ -52,6 +137,50 @@ class ProviderSpec:
     def label(self) -> str:
         return self.display_name or self.name.title()
 
+    def resolve_endpoint_class(self, api_base: str | None = None) -> str:
+        """Return the endpoint class for this spec given the effective base.
+
+        An explicit ``endpoint_class`` describes the *declared* endpoint, so it
+        only applies when the resolved base actually is that endpoint. A user
+        who repoints ``providers.deepseek.apiBase`` at a relay must not be told
+        their traffic is ``first_party``: for an overridden base the class is
+        re-derived from the hostname (``local`` for loopback/LAN, else
+        ``unknown``). An unflattering label is the point — the class is what a
+        denial message and the audit trail report.
+
+        When ``endpoint_class`` is unset the derivation is: a known gateway
+        stays a ``gateway`` (never "first_party"), a local server is ``local``,
+        a ``custom``/``requires_api_base`` entry pointing at loopback or a LAN
+        name is ``local``, and everything else is ``unknown``.
+        """
+
+        if self.endpoint_class:
+            if self._matches_declared_endpoint(api_base):
+                return self.endpoint_class
+            # Overridden base: the declaration no longer describes the endpoint
+            # the request will actually hit.
+            return "local" if host_looks_local(api_base) else DEFAULT_ENDPOINT_CLASS
+        if self.is_local or host_looks_local(api_base):
+            return "local"
+        if self.is_gateway:
+            return "gateway"
+        return DEFAULT_ENDPOINT_CLASS
+
+    def _matches_declared_endpoint(self, api_base: str | None) -> bool:
+        """Is ``api_base`` the endpoint this spec declared (or nothing at all)?
+
+        No base -> the SDK/spec default is used, so the declaration holds. A
+        base with no declared counterpart (``anthropic``/``openai``, whose SDK
+        picks the vendor default) cannot be verified, so the declaration is not
+        trusted for it.
+        """
+
+        if not api_base:
+            return True
+        if not self.default_api_base:
+            return False
+        return endpoint_host(api_base) == endpoint_host(self.default_api_base)
+
 
 PROVIDERS: tuple[ProviderSpec, ...] = (
     ProviderSpec(
@@ -62,6 +191,8 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         is_direct=True,
         requires_api_base=True,
+        # Deliberately unclassified: `api_base` is user-supplied, so the class
+        # is derived per-construction (local for loopback/LAN, else unknown).
     ),
     ProviderSpec(
         name="openrouter",
@@ -70,6 +201,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         display_name="OpenRouter",
         backend="openai_compat",
         is_gateway=True,
+        endpoint_class="gateway",
         detect_by_key_prefix="sk-or-",
         detect_by_base_keyword="openrouter",
         default_api_base="https://openrouter.ai/api/v1",
@@ -82,6 +214,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         display_name="Requesty",
         backend="openai_compat",
         is_gateway=True,
+        endpoint_class="gateway",
         detect_by_base_keyword="requesty",
         default_api_base="https://router.requesty.ai/v1",
         supports_prompt_caching=True,
@@ -93,6 +226,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         display_name="Forge",
         backend="openai_compat",
         is_gateway=True,
+        endpoint_class="gateway",
         detect_by_base_keyword="forge.tensorblock.co",
         default_api_base="https://api.forge.tensorblock.co/v1",
         # Forge resolves bare model ids, not ``vendor/model`` — unlike the
@@ -105,6 +239,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         env_key="ANTHROPIC_API_KEY",
         display_name="Anthropic",
         backend="anthropic",
+        endpoint_class="first_party",
         supports_prompt_caching=True,
     ),
     ProviderSpec(
@@ -113,6 +248,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         env_key="OPENAI_API_KEY",
         display_name="OpenAI",
         backend="openai_compat",
+        endpoint_class="first_party",
         supports_max_completion_tokens=True,
     ),
     ProviderSpec(
@@ -121,6 +257,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         env_key="DEEPSEEK_API_KEY",
         display_name="DeepSeek",
         backend="openai_compat",
+        endpoint_class="first_party",
         default_api_base="https://api.deepseek.com",
         thinking_style="thinking_type",
     ),
@@ -130,6 +267,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         env_key="GEMINI_API_KEY",
         display_name="Gemini",
         backend="openai_compat",
+        endpoint_class="first_party",
         default_api_base="https://generativelanguage.googleapis.com/v1beta/openai/",
     ),
     ProviderSpec(
@@ -138,6 +276,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         env_key="ZAI_API_KEY",
         display_name="Zhipu AI",
         backend="openai_compat",
+        endpoint_class="aggregator",
         default_api_base="https://open.bigmodel.cn/api/paas/v4",
         # GLM takes the same ``thinking: {"type": ...}`` body as DeepSeek.
         thinking_style="thinking_type",
@@ -148,6 +287,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         env_key="DASHSCOPE_API_KEY",
         display_name="DashScope",
         backend="openai_compat",
+        endpoint_class="aggregator",
         default_api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
         thinking_style="enable_thinking",
     ),
@@ -157,6 +297,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         env_key="MINIMAX_API_KEY",
         display_name="MiniMax",
         backend="openai_compat",
+        endpoint_class="aggregator",
         default_api_base="https://api.minimax.io/v1",
     ),
     ProviderSpec(
@@ -166,6 +307,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         display_name="vLLM/Local",
         backend="openai_compat",
         is_local=True,
+        endpoint_class="local",
         requires_api_base=True,
     ),
     ProviderSpec(
@@ -175,6 +317,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         display_name="Ollama",
         backend="openai_compat",
         is_local=True,
+        endpoint_class="local",
         detect_by_base_keyword="11434",
         default_api_base="http://localhost:11434/v1",
     ),

--- a/tests/test_provider_egress.py
+++ b/tests/test_provider_egress.py
@@ -1,0 +1,403 @@
+"""Tests for the model-egress policy (P0-1).
+
+Covers three layers:
+
+1. ``evaluate_provider_egress`` — the pure decision kernel (no I/O, so the
+   cases below are exhaustive rather than illustrative).
+2. ``core.providers.registry`` endpoint classification — including that the
+   pre-existing ``is_gateway`` boolean still works, since other tests and
+   callers read it.
+3. The wiring in ``core.config.make_llm_provider`` — the single provider
+   construction point — plus the ``warn`` rollout mode.
+
+No network access: an LLM provider client is constructed (lazily) but never
+used, and the deny cases raise before construction.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from loguru import logger
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.config import ConfigError, DeepCodeConfig, make_llm_provider
+from core.providers.egress import (
+    ALLOW_ENV,
+    BLOCK_ENV,
+    MODE_ENV,
+    egress_mode,
+    evaluate_provider_egress,
+    parse_domain_list,
+    resolve_egress_policy,
+)
+from core.providers.registry import (
+    ProviderSpec,
+    find_by_name,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_egress_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every test starts from an unconfigured policy.
+
+    Without this, a developer's shell (or a sibling test) that exports
+    ``DEEPCODE_EGRESS_*`` would silently change the meaning of these cases.
+    """
+
+    for name in (ALLOW_ENV, BLOCK_ENV, MODE_ENV):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _config(*, api_base: str | None, egress: dict | None = None) -> DeepCodeConfig:
+    """A minimal deepseek config pointed at ``api_base`` (no network use)."""
+
+    raw: dict = {
+        "agents": {"defaults": {"provider": "deepseek", "model": "deepseek-chat"}},
+        "providers": {
+            "deepseek": {"apiKey": "sk-test-not-a-real-key", "apiBase": api_base},
+        },
+    }
+    if egress is not None:
+        raw["providers"]["egress"] = egress
+    return DeepCodeConfig.model_validate(raw)
+
+
+# -- 1. pure decision kernel -------------------------------------------------
+
+
+def test_empty_api_base_is_allowed_and_unpoliced():
+    for value in (None, "", "   "):
+        decision = evaluate_provider_egress(
+            value, allowed_domains=("api.deepseek.com",)
+        )
+        assert decision.allowed is True
+        assert decision.host is None
+        # No endpoint to judge -> no pretend reason either way.
+        assert decision.reason is None
+        assert decision.endpoint_class == "unknown"
+
+
+def test_allow_listed_host_is_allowed_and_reason_is_none():
+    decision = evaluate_provider_egress(
+        "https://api.deepseek.com/v1",
+        endpoint_class="first_party",
+        allowed_domains=("api.deepseek.com",),
+    )
+    assert decision.allowed is True
+    assert decision.host == "api.deepseek.com"
+    assert decision.endpoint_class == "first_party"
+    assert decision.reason is None
+
+
+def test_allow_list_matches_subdomains_not_suffix_lookalikes():
+    allowed = ("deepseek.com",)
+    assert evaluate_provider_egress(
+        "https://api.deepseek.com/v1", allowed_domains=allowed
+    ).allowed
+    # "evil-deepseek.com" must not match "deepseek.com" (no partial-label match).
+    denied = evaluate_provider_egress(
+        "https://evil-deepseek.com/v1", allowed_domains=allowed
+    )
+    assert denied.allowed is False
+
+
+def test_host_outside_allow_list_is_denied_with_actionable_reason():
+    decision = evaluate_provider_egress(
+        "https://api.siliconflow.cn/v1",
+        endpoint_class="unknown",
+        allowed_domains=("api.deepseek.com",),
+    )
+    assert decision.allowed is False
+    assert decision.host == "api.siliconflow.cn"
+    assert decision.reason is not None
+    assert "api.siliconflow.cn" in decision.reason
+    assert "allow-list" in decision.reason
+    assert "endpoint_class=unknown" in decision.reason
+
+
+def test_blocked_host_is_denied_even_without_allow_list():
+    # An empty allow-list means "allow all unless blocked" — this is the
+    # preserved historical meaning, and the block-list must still bite.
+    decision = evaluate_provider_egress(
+        "https://api.siliconflow.cn/v1",
+        blocked_domains=("siliconflow.cn",),
+    )
+    assert decision.allowed is False
+    assert decision.host == "api.siliconflow.cn"
+    assert decision.reason is not None
+    assert "block-list" in decision.reason
+
+
+def test_block_wins_over_allow_for_the_same_host():
+    decision = evaluate_provider_egress(
+        "https://api.siliconflow.cn/v1",
+        allowed_domains=("siliconflow.cn",),
+        blocked_domains=("api.siliconflow.cn",),
+    )
+    assert decision.allowed is False
+
+
+def test_empty_allow_list_keeps_allow_all_semantics():
+    decision = evaluate_provider_egress("https://anything.example.com/v1")
+    assert decision.allowed is True
+    assert decision.host == "anything.example.com"
+    assert decision.reason is None
+
+
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "api.deepseek.com/v1",  # missing scheme
+        "ftp://api.deepseek.com/v1",  # unsupported scheme
+        "file:///etc/passwd",
+        "https://",  # no hostname
+        "http://[::1",  # unparseable (invalid IPv6)
+    ],
+)
+def test_unparseable_or_non_http_base_is_denied(api_base: str):
+    decision = evaluate_provider_egress(api_base)
+    assert decision.allowed is False
+    assert decision.reason is not None
+
+
+def test_http_is_accepted_because_local_servers_use_it():
+    # Ollama/vLLM over loopback is plain HTTP on purpose; the allow-list, not
+    # the scheme, is what constrains it.
+    decision = evaluate_provider_egress(
+        "http://localhost:11434/v1",
+        endpoint_class="local",
+        allowed_domains=("localhost",),
+    )
+    assert decision.allowed is True
+    assert decision.host == "localhost"
+
+
+def test_invalid_policy_entry_fails_closed():
+    # A malformed allow-list entry is not silently dropped: is_domain_allowed
+    # rejects the whole policy, so a typo cannot widen the gate.
+    decision = evaluate_provider_egress(
+        "https://api.deepseek.com/v1",
+        allowed_domains=("not a domain/with/slash",),
+    )
+    assert decision.allowed is False
+
+
+# -- 2. endpoint classification ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("deepseek", "first_party"),
+        ("gemini", "first_party"),
+        ("anthropic", "first_party"),
+        ("openai", "first_party"),
+        ("openrouter", "gateway"),
+        ("requesty", "gateway"),
+        ("forge", "gateway"),
+        ("zhipu", "aggregator"),
+        ("dashscope", "aggregator"),
+        ("minimax", "aggregator"),
+        ("ollama", "local"),
+        ("vllm", "local"),
+    ],
+)
+def test_endpoint_class_per_spec_entry(name: str, expected: str):
+    spec = find_by_name(name)
+    assert spec is not None
+    assert spec.resolve_endpoint_class(spec.default_api_base or None) == expected
+
+
+def test_custom_endpoint_is_unknown_unless_it_looks_local():
+    custom = find_by_name("custom")
+    assert custom is not None
+    assert custom.resolve_endpoint_class("https://api.siliconflow.cn/v1") == "unknown"
+    assert custom.resolve_endpoint_class("http://localhost:8080/v1") == "local"
+    assert custom.resolve_endpoint_class("http://127.0.0.1:8000/v1") == "local"
+    assert custom.resolve_endpoint_class("http://ollama:11434/v1") == "local"
+    assert custom.resolve_endpoint_class(None) == "unknown"
+
+
+def test_is_gateway_still_works_alongside_endpoint_class():
+    # Existing callers/tests read the boolean; the upgrade must not break it.
+    assert find_by_name("openrouter").is_gateway is True
+    assert find_by_name("minimax").is_gateway is False
+    assert find_by_name("openrouter").endpoint_class == "gateway"
+
+
+def test_unset_class_derives_pessimistically():
+    gateway = ProviderSpec(name="x", keywords=(), env_key="", is_gateway=True)
+    assert gateway.resolve_endpoint_class("https://relay.example.com/v1") == "gateway"
+
+    unclassified = ProviderSpec(name="y", keywords=(), env_key="")
+    assert unclassified.resolve_endpoint_class("https://who-knows.example/v1") == (
+        "unknown"
+    )
+
+    # An explicit class always wins — including a pessimistic one.
+    claimed = ProviderSpec(
+        name="z", keywords=(), env_key="", is_gateway=True, endpoint_class="unknown"
+    )
+    assert claimed.resolve_endpoint_class(None) == "unknown"
+
+
+def test_repointed_api_base_is_not_flattered_by_the_specs_class():
+    # `providers.deepseek.apiBase` pointing at a relay must not report
+    # first_party: the class describes the endpoint the request will hit.
+    deepseek = find_by_name("deepseek")
+    assert deepseek.resolve_endpoint_class("https://api.siliconflow.cn/v1") == "unknown"
+    assert deepseek.resolve_endpoint_class("http://localhost:8080/v1") == "local"
+
+    # No declared base to compare against -> the explicit class is not trusted.
+    anthropic = find_by_name("anthropic")
+    assert anthropic.resolve_endpoint_class("https://relay.example.com") == "unknown"
+
+
+# -- 3. env / config policy resolution --------------------------------------
+
+
+def test_parse_domain_list_trims_lowercases_and_dedupes():
+    assert parse_domain_list(None) == ()
+    assert parse_domain_list("") == ()
+    assert parse_domain_list(" , , ") == ()
+    assert parse_domain_list(
+        " api.DeepSeek.com , api.siliconflow.cn,,API.deepseek.COM "
+    ) == (
+        "api.deepseek.com",
+        "api.siliconflow.cn",
+    )
+    assert parse_domain_list(["a.com", " a.com ", "", 7]) == ("a.com",)  # type: ignore[list-item]
+
+
+def test_resolve_policy_reads_config_and_env_union(monkeypatch: pytest.MonkeyPatch):
+    config = _config(
+        api_base=None,
+        egress={
+            "allowedDomains": ["api.deepseek.com"],
+            "blockedDomains": ["evil.example.com"],
+        },
+    )
+    monkeypatch.setenv(ALLOW_ENV, "api.siliconflow.cn, ")
+    monkeypatch.setenv(BLOCK_ENV, "attacker.example")
+
+    policy = resolve_egress_policy(config)
+    assert policy.allowed_domains == ("api.deepseek.com", "api.siliconflow.cn")
+    assert policy.blocked_domains == ("evil.example.com", "attacker.example")
+    # Unset mode falls back to enforce: a missing var must not open the gate.
+    assert policy.mode == "enforce"
+
+
+def test_env_lists_extend_rather_than_replace_config():
+    # An env allow-list cannot un-block a host the config blocks (deny wins);
+    # it also cannot drop a host the config allows.
+    config = _config(
+        api_base=None,
+        egress={"allowedDomains": ["api.deepseek.com"], "blockedDomains": []},
+    )
+    policy = resolve_egress_policy(config)
+    decision = evaluate_provider_egress(
+        "https://api.siliconflow.cn/v1",
+        allowed_domains=policy.allowed_domains,
+        blocked_domains=policy.blocked_domains,
+    )
+    assert decision.allowed is False
+
+
+def test_policy_from_plain_dict_and_from_missing_config():
+    # A dict-shaped config (JSON round-trip, tests) must be readable too.
+    policy = resolve_egress_policy(
+        {"providers": {"egress": {"allowedDomains": ["a.example.com"]}}}
+    )
+    assert policy.allowed_domains == ("a.example.com",)
+
+    # Anything that is not a DEEPCODE config resolves to the neutral policy.
+    neutral = resolve_egress_policy(None)
+    assert neutral.allowed_domains == ()
+    assert neutral.blocked_domains == ()
+    assert neutral.mode == "enforce"
+    assert resolve_egress_policy(object()).allowed_domains == ()
+
+
+def test_unrecognized_mode_falls_back_to_enforce(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(MODE_ENV, "yolo")
+    assert egress_mode() == "enforce"
+    assert resolve_egress_policy(None).mode == "enforce"
+
+    monkeypatch.setenv(MODE_ENV, " WARN ")
+    assert egress_mode() == "warn"
+    assert resolve_egress_policy(None).mode == "warn"
+
+    monkeypatch.delenv(MODE_ENV)
+    assert egress_mode() == "enforce"
+
+
+def test_config_mode_is_honored(monkeypatch: pytest.MonkeyPatch):
+    config = _config(api_base=None, egress={"mode": "warn"})
+    assert resolve_egress_policy(config).mode == "warn"
+    # Env still wins over the config file.
+    monkeypatch.setenv(MODE_ENV, "enforce")
+    assert resolve_egress_policy(config).mode == "enforce"
+
+
+# -- 4. wiring in make_llm_provider -----------------------------------------
+
+
+def test_make_llm_provider_denies_host_outside_allow_list(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv(ALLOW_ENV, "api.deepseek.com")
+    config = _config(api_base="https://api.siliconflow.cn/v1")
+
+    with pytest.raises(ConfigError) as excinfo:
+        make_llm_provider(config)
+
+    message = str(excinfo.value)
+    # Actionable: names the host, the class, and every knob that would allow it.
+    assert "api.siliconflow.cn" in message
+    assert "endpoint_class=unknown" in message
+    assert ALLOW_ENV in message
+    assert BLOCK_ENV in message
+    assert MODE_ENV in message
+    assert "warn" in message
+
+
+def test_make_llm_provider_allows_first_party_host(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(ALLOW_ENV, "api.deepseek.com")
+    config = _config(api_base="https://api.deepseek.com")
+
+    provider = make_llm_provider(config)
+
+    # Constructed lazily — no request is made here.
+    assert provider.__class__.__name__ == "OpenAICompatProvider"
+    assert provider._effective_base == "https://api.deepseek.com"
+
+
+def test_make_llm_provider_allows_blocked_free_host_without_allow_list(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv(BLOCK_ENV, "api.siliconflow.cn")
+    config = _config(api_base="https://api.deepseek.com")
+    assert make_llm_provider(config) is not None
+
+
+def test_warn_mode_logs_instead_of_raising(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(ALLOW_ENV, "api.deepseek.com")
+    monkeypatch.setenv(MODE_ENV, "warn")
+    config = _config(api_base="https://api.siliconflow.cn/v1")
+
+    captured: list[str] = []
+    sink_id = logger.add(lambda message: captured.append(message), level="WARNING")
+    try:
+        provider = make_llm_provider(config)
+    finally:
+        logger.remove(sink_id)
+
+    assert provider is not None
+    assert any("api.siliconflow.cn" in message for message in captured)
+    assert any("egress blocked" in message for message in captured)


### PR DESCRIPTION
## Summary

A provider endpoint is configured as a plain string, and whoever terminates that connection reads every prompt, tool result and credential in the request body. The repository already had a domain policy for agent-initiated web fetches (`core.network.safe_http`, used by the web tools); model traffic bypassed it entirely.

This applies the same idea to provider endpoints.

## Changes

| file | what |
|---|---|
| `core/providers/egress.py` | new - pure `evaluate_provider_egress()` over the base URL, an `EgressPolicy`, and env/config parsing |
| `core/providers/registry.py` | `ProviderSpec` gains `endpoint_class` beside the existing `is_gateway` flag; `resolve_endpoint_class()` derives it |
| `core/config.py` | `providers.egress` block + `_enforce_provider_egress()` applied once in `make_llm_provider` |

`endpoint_class` is one of `first_party` / `gateway` / `aggregator` / `local` / `unknown`, so the policy can say what it is talking to rather than inferring from a hostname. A repointed base URL is never reported as `first_party` - `resolve_endpoint_class()` only trusts an explicit class while the resolved base still matches the spec's declared endpoint.

## Security Considerations

**Attack surface changed.** Which hosts the client will send prompts, tool output and credentials to is now a checked decision rather than an unexamined string.

**Why this is fail-safe.**
- **Default behaviour is unchanged.** An empty allow-list keeps the historical allow-unless-blocked meaning, so an install that configures nothing sees no new refusals. Only a deployment that opts in gets refusals.
- `DEEPCODE_EGRESS_MODE=warn` logs instead of raising, as the rollout escape hatch.
- A denial raises the module's existing `ConfigError` naming the host, the endpoint class, the base URL, and the exact variables that would allow it - so the failure is actionable rather than mysterious.
- Enforcement happens once per provider construction, not per request, so there is no hot-path cost and no partial-request state.

**One deliberate behaviour change to flag.** A scheme-less or non-`http(s)` `api_base` (e.g. `api.example.com/v1`) now fails at provider construction with a clear error instead of failing later at request time. Those values never worked; the error is just earlier and clearer. `warn` mode is the escape hatch if any real configuration relies on the late failure.

**What this is not.** It is not an integrity control. A host on the allow-list can still rewrite the tool calls the model returns - that needs provider-side signing, which nothing deploys today. This narrows *where* the client talks, not *what it is told*.

**Security verification.** `tests/test_provider_egress.py` (40 cases): the pure kernel (allow / deny / blocked host / empty base / bad scheme), endpoint-class resolution per spec entry including the repointed-base case, allow/block list parsing from both env and config, `warn` mode not raising, and an end-to-end check that `make_llm_provider` raises for a host outside a configured allow-list while `https://api.deepseek.com` passes. No network calls.

## Tests

```
pytest tests/test_provider_egress.py tests/test_provider_cli.py tests/test_config_layering.py \
       tests/test_config_layers.py tests/test_config_errors.py tests/test_model_compat.py \
       tests/test_forge_provider.py tests/test_requesty_provider.py tests/minimax_provider_test.py \
       tests/test_llm_runtime_connections.py -q
105 passed
```

Verified under the repository's own `pyproject.toml` pytest config. `ruff check` and `ruff format` clean for the files this PR touches.

## Notes

- The `is_gateway` flag is preserved unchanged; `endpoint_class` is additive so nothing that reads the current field breaks.
- The `ruff` findings that remain in `core/config.py` (SIM102 x2, TRY004, RUF022) are pre-existing: the unsorted `__all__` is upstream's own ordering, and this PR does not touch those lines.
- Committed with `--no-verify` because the local `pre-commit` framework needs `/bin/bash`, which this Windows checkout lacks. `ruff` was run directly.